### PR TITLE
Nonlinear weighting across the grounding zone

### DIFF
--- a/src/physics/topography.f90
+++ b/src/physics/topography.f90
@@ -1593,12 +1593,12 @@ end if
                 call calc_bmb_gl_pmpt(bmb, bmb_grnd, bmb_shlf, H_grnd, gz_Hg0, gz_Hg1, &
                     gz_nx, boundaries, 1)
 
-            case("pmpt-polyref")
+            case("pmpt-gausscdf")
 
                 call calc_bmb_gl_pmpt(bmb, bmb_grnd, bmb_shlf, H_grnd, gz_Hg0, gz_Hg1, &
                     gz_nx, boundaries, 2)
-
-            case("pmpt-gausscdf")
+                    
+            case("pmpt-polyref")
 
                 call calc_bmb_gl_pmpt(bmb, bmb_grnd, bmb_shlf, H_grnd, gz_Hg0, gz_Hg1, &
                     gz_nx, boundaries, 3)
@@ -1846,9 +1846,9 @@ end if
                         ! Within grounding zone
                         wt = (Hg_int(i1,j1)-gz_Hg0) / (gz_Hg1 - gz_Hg0)
                     else if (method .eq. 2) then
-                        wt = polyref_tides(m * Hg_int(i1,j1) + p)
-                    else if (method .eq. 3) then
                         wt = cdf(m * Hg_int(i1,j1) + p, mu_ssh, sigma_ssh)
+                    else if (method .eq. 3) then
+                        wt = polyref_tides(m * Hg_int(i1,j1) + p)
                     end if
 
                     ! Get subgrid bmb weighted between floating and grounded contributions


### PR DESCRIPTION
![polyref_trajectory](https://github.com/user-attachments/assets/9ab76764-5e24-4e32-81f6-ea15593e70cd)

**Left panel**: time series of the tidal sea-surface height perturbation from Rignot et al. (2024). 
**Right panel**: resulting probability density function (pdf, "how frequent is a sea-surface height perturbation"?) and cumulative density function (cdf, "how frequent are tides below a given value" - e.g. there is a frequency of about 0.85 that the tidal anomaly is 50 cm or less). Two fits of the cdf are shown: one uses the cdf of a normal distribution (relies on error function `erf`) and the other uses a reference polynomial of degree 5. The former one should be used, unless we want to get experimental (the polynomial can be tuned to do whatever we want)...

Conceptually, we want to associate the lowest tides with `gz_Hg0` and the highest ones with `gz_Hg1`. To do this, we apply a linear map that is then passed to the cdf fit. The thus obtained weight has following statistical meaning: "how often is a point with gz_Hg0 < H_af < gz_Hg1` grounded?". The result is shown below:

![pmpt-comparison](https://github.com/user-attachments/assets/b7825da4-4f1b-49c6-abdd-45da161c1d64)

For the relatively coarse resolutions we are running, I don't expect this to give very different results compared to the linear version of PMPT that was implemented so far. I think this can however become crucial on higher resolutions (melt is larger for cells close to `gz_Hg0` and smaller for cells close to `gz_Hg1`).

I am waiting for the data of Chen et al. (2023) to confirm that the nonlinearities that are implemented here are adequate regardless of the region treated.

Diving into the code:
- topography.f90 l. 1590: case distinction between "pmpt-lin", "pmpt-gausscdf" and "pmpt-polyref", which now need to be specified in the namelist.
- l 1798: define parameters of gaussian cdf and the linear map between tides and `gz_Hg`.
- l 1845: case distinction (internally).

If this PR is accepted, the according namelist entry of yelmox shoud be changed to:
```
    bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt;
                                            ! "nmp": no melt; "pmpt-lin" partial melt with linear tide;
                                            ! "pmpt-gausscdf" partial melt with realistic tide;
                                            ! "pmpt-plyref" partial melt with tunable tides (experimental)
```