### PR TITLE
Add SSA energy-formulation momentum solver

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Yelmo release/tag notes
 
+## Unreleased
+
+- New SSA momentum-balance formulation: **energy-based assembler** (`src/physics/solver_ssa_ac_energy.f90`), selectable via the new `ydyn.ssa_solver` parameter (`"residual"` | `"energy"`). The energy form assembles the symmetric positive-definite Hessian of the discrete viscous-energy density (membrane + shear + basal drag + driving), with η, β, H frozen per Picard iteration. Algebraic identity `K_inner = -A_residual_inner * dx*dy` for interior cells; calving-front BC encoded as a linear boundary-work term in the RHS rather than a one-sided FD stencil. SSA and DIVA both dispatch to the new assembler when `ssa_solver = "energy"`. The `ssa_lis_opt` namelist parameter has been split into `ssa_lis_opt_residual` and `ssa_lis_opt_energy` so each formulation carries its own LIS solver settings (defaults: `bicgsafe + jacobi` for residual, `cg + jacobi` for energy — CG is safe because the energy Hessian is SPD by construction).
+- **initmip-grl finding (GRL-16KM, 100 yr, AB-SAM, dt_method=0)**: with `ssa_lat_bc="all"` (lateral BC applied to all ice fronts including grounded marine), the residual solver takes 48.9 s, the energy solver 5.8 s — **8.4× speedup**. Picard iterations: 2030 (residual) vs 135 (energy). The residual solver is BC-sensitive — switching from `"floating"` to `"all"` raises `uxy_s_max` from 4948 → 5424 m/yr and triples the Picard work. The energy solver is essentially insensitive to this switch (`uxy_s_max` literally identical, 3567 m/yr in both). This supports the prior intuition that the residual one-sided FD discretization of the calving-front BC is deficient at grounded marine fronts; the energy formulation's variational BC handling avoids the instability.
+- New defaults: `ssa_solver = "energy"` in all parameter files; `ssa_lat_bc = "all"` in production files (`yelmo_initmip.nml`, `yelmo_TROUGH-F17.nml`, `yelmo_MISMIP+.nml`, `yelmo_calvingmip.nml`). Idealised infinite-slab benchmarks (`yelmo_SLAB-S06.nml`, `yelmo_ISMIPHOM.nml`) keep `ssa_lat_bc = "slab"` since their physics requires the slab extension.
+- Algebraic-identity validation test: `tests/test_ssa_energy.f90` (build target `make ssa_energy`). Confirms the energy assembler matches `-A_residual * dx*dy` to single-precision roundoff on a periodic synthetic grid.
+
 ## v1.15 (2026-01-19)
 
 - Use of Gaussian Quadrature module from fesm-utils for calculating the Jacobian of velocity (strain-rate tensor), vertical velocity, dynamic viscosity (DIVA, SSA), basal friction, and other quantities.

--- a/config/Makefile
+++ b/config/Makefile
@@ -133,6 +133,13 @@ levelset : yelmo-static tests/test_levelset.f90
 		@echo "    test_levelset.x is ready."
 		@echo " "
 
+ssa_energy : yelmo-static tests/test_ssa_energy.f90
+		$(FC) $(DFLAGS) $(FFLAGS) $(INC_FESMUTILS) $(INC_LIS) -o $(bindir)/test_ssa_energy.x tests/test_ssa_energy.f90 \
+			-L${CURDIR}/libyelmo/include -lyelmo $(LFLAGS)
+		@echo " "
+		@echo "    test_ssa_energy.x is ready."
+		@echo " "
+
 mismip1 : yelmo-static
 		$(FC) $(DFLAGS) $(FFLAGS) $(INC_FESMUTILS) $(INC_LIS) -o $(bindir)/yelmo_mismip.x tests/yelmo_mismip_new.f90 \
 			-L${CURDIR}/libyelmo/include -lyelmo $(LFLAGS)

--- a/config/Makefile_yelmo.mk
+++ b/config/Makefile_yelmo.mk
@@ -64,6 +64,10 @@ $(objdir)/solver_ssa_ac.o: $(srcdir)/physics/solver_ssa_ac.f90 $(objdir)/yelmo_d
 							$(objdir)/yelmo_tools.o $(objdir)/solver_linear.o
 	$(FC) $(DFLAGS) $(FFLAGS) $(INC_LINEAR) $(INC_FESMUTILS) -c -o $@ $<
 
+$(objdir)/solver_ssa_ac_energy.o: $(srcdir)/physics/solver_ssa_ac_energy.f90 $(objdir)/yelmo_defs.o \
+							$(objdir)/yelmo_tools.o $(objdir)/solver_linear.o $(objdir)/solver_ssa_ac.o
+	$(FC) $(DFLAGS) $(FFLAGS) $(INC_LINEAR) $(INC_FESMUTILS) -c -o $@ $<
+
 $(objdir)/solver_linear.o: $(srcdir)/physics/solver_linear.F90 $(objdir)/yelmo_defs.o \
 							$(objdir)/yelmo_tools.o
 	$(FC) $(DFLAGS) $(FFLAGS) $(INC_LINEAR) $(INC_FESMUTILS) -c -o $@ $<
@@ -97,12 +101,14 @@ $(objdir)/velocity_sia.o: $(srcdir)/physics/velocity_sia.f90 \
 
 $(objdir)/velocity_ssa.o: $(srcdir)/physics/velocity_ssa.f90 \
 						  	$(objdir)/yelmo_defs.o $(objdir)/yelmo_tools.o $(objdir)/basal_dragging.o \
-						  	$(objdir)/solver_ssa_ac.o $(objdir)/velocity_general.o
+						  	$(objdir)/solver_ssa_ac.o $(objdir)/solver_ssa_ac_energy.o \
+						  	$(objdir)/velocity_general.o
 	$(FC) $(DFLAGS) $(FFLAGS) $(INC_FESMUTILS) -c -o $@ $<
 
 $(objdir)/velocity_diva.o: $(srcdir)/physics/velocity_diva.f90 \
 						  	$(objdir)/yelmo_defs.o $(objdir)/yelmo_tools.o $(objdir)/basal_dragging.o \
-						  	$(objdir)/solver_ssa_ac.o $(objdir)/velocity_general.o
+						  	$(objdir)/solver_ssa_ac.o $(objdir)/solver_ssa_ac_energy.o \
+						  	$(objdir)/velocity_general.o
 	$(FC) $(DFLAGS) $(FFLAGS) $(INC_FESMUTILS) -c -o $@ $<
 
 $(objdir)/velocity_l1l2.o: $(srcdir)/physics/velocity_l1l2.f90 \
@@ -220,6 +226,7 @@ yelmo_physics =  	   $(objdir)/basal_dragging.o \
 					   $(objdir)/mass_conservation.o \
 					   $(objdir)/runge_kutta.o \
 					   $(objdir)/solver_ssa_ac.o \
+					   $(objdir)/solver_ssa_ac_energy.o \
 					   $(objdir)/solver_linear.o \
 					   $(objdir)/solver_tridiagonal.o \
 					   $(objdir)/solver_advection.o \

--- a/par-gmd/yelmo_Antarctica.nml
+++ b/par-gmd/yelmo_Antarctica.nml
@@ -159,8 +159,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 20              ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par-gmd/yelmo_EISMINT_expa.nml
+++ b/par-gmd/yelmo_EISMINT_expa.nml
@@ -144,8 +144,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 2               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par-gmd/yelmo_EISMINT_expf.nml
+++ b/par-gmd/yelmo_EISMINT_expf.nml
@@ -145,8 +145,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 2               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par-gmd/yelmo_EISMINT_moving.nml
+++ b/par-gmd/yelmo_EISMINT_moving.nml
@@ -146,8 +146,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i minres -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 100             ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par-gmd/yelmo_HALFAR.nml
+++ b/par-gmd/yelmo_HALFAR.nml
@@ -146,8 +146,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 2               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par-gmd/yelmo_MISMIP3D.nml
+++ b/par-gmd/yelmo_MISMIP3D.nml
@@ -139,8 +139,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 20              ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_ISMIPHOM.nml
+++ b/par/yelmo_ISMIPHOM.nml
@@ -142,7 +142,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"         ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "slab"          ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_MISMIP+.nml
+++ b/par/yelmo_MISMIP+.nml
@@ -153,8 +153,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"         ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 10              ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_SLAB-S06.nml
+++ b/par/yelmo_SLAB-S06.nml
@@ -160,7 +160,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i bicgsafe -p jacobi -maxiter 1000 -tol 1.0e-6 -initx_zeros false"  ! See Lis library
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i bicgsafe -p jacobi -maxiter 1000 -tol 1.0e-6 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 1000 -tol 1.0e-6 -initx_zeros false"         ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "slab"          ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_TROUGH-F17.nml
+++ b/par/yelmo_TROUGH-F17.nml
@@ -160,8 +160,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none" 
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i minres -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 20              ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_calvingmip.nml
+++ b/par/yelmo_calvingmip.nml
@@ -138,8 +138,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
-    ssa_lat_bc          = "floating"           ! "all", "marine", "floating", "none", "slab"
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i minres -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"  ! See Lis library
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"                ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 100             ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_initmip.nml
+++ b/par/yelmo_initmip.nml
@@ -217,8 +217,10 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver              = "energy"    ! "residual" | "energy"
+    ssa_lis_opt_residual    = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 20              ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/src/physics/solver_ssa_ac.f90
+++ b/src/physics/solver_ssa_ac.f90
@@ -17,8 +17,11 @@ module solver_ssa_ac
     ! Routines that make use of the linear_solver_class object defined in the module solver_linear.F90:
     public :: linear_solver_save_velocity
     public :: linear_solver_matrix_ssa_ac_csr_2D
-    
-contains 
+
+    ! Helper used by alternative SSA assemblers (e.g. solver_ssa_ac_energy):
+    public :: stagger_visc_aa_ab
+
+contains
     
     subroutine linear_solver_save_velocity(ux,uy,lgs,ulim)
         ! Extract velocity solution from lgs object. 

--- a/src/physics/solver_ssa_ac_energy.f90
+++ b/src/physics/solver_ssa_ac_energy.f90
@@ -1,0 +1,469 @@
+module solver_ssa_ac_energy
+    ! SSA momentum solver, energy formulation.
+    !
+    ! Assembles the symmetric positive-(semi)definite Hessian K of the
+    ! discretised SSA energy density
+    !
+    !     W = N_aa·(2 ux^2 + 2 vy^2 + 2 ux vy + 1/2 (uy + vx)^2)   ! membrane + shear
+    !       + 1/2 beta (u^2 + v^2)                                 ! basal drag
+    !       + rho_i g H (u s_x + v s_y)                            ! driving (gravitational PE)
+    !
+    ! integrated over the C-grid. With (eta, beta, H) frozen per Picard
+    ! iteration the energy is quadratic in (u, v); the Hessian K is symmetric
+    ! and positive (semi-)definite, so CG + AMG can be used in place of
+    ! BiCGStab on the non-symmetric residual matrix.
+    !
+    ! Algebraic identity: for inner ac-nodes (no boundary or mask special-cases),
+    !
+    !     K_inner   = - A_residual_inner · dx · dy
+    !     b_inner_E = - taud_inner       · dx · dy
+    !
+    ! where (A_residual, b_residual) is the matrix/RHS produced by
+    ! linear_solver_matrix_ssa_ac_csr_2D in solver_ssa_ac.f90. The two
+    ! formulations therefore yield the same physical solution at inner cells.
+    ! Boundary handling differs — see notes below.
+    !
+    ! Staggering convention: yelmo-fortran C-grid. ux(i,j) lives at the RIGHT
+    ! face of aa-cell (i,j); uy(i,j) lives at the TOP face. (Yelmo.jl uses
+    ! the opposite convention with ux on the LEFT face — stencils here are
+    ! re-derived from the energy density to match the Fortran convention.)
+
+    use yelmo_defs, only : sp, dp, wp, io_unit_err, TOL, TOL_UNDERFLOW, is_equal
+    use yelmo_tools, only : boundary_code, get_neighbor_indices_bc_codes
+    use solver_linear
+    use solver_ssa_ac, only : stagger_visc_aa_ab
+
+    implicit none
+
+    private
+    public :: linear_solver_matrix_ssa_ac_csr_2D_energy
+
+contains
+
+    subroutine linear_solver_matrix_ssa_ac_csr_2D_energy(lgs,ux,uy,beta_acx,beta_acy, &
+                            N_aa,ssa_mask_acx,ssa_mask_acy,mask_frnt,H_ice,f_ice,taud_acx, &
+                            taud_acy,taul_int_acx,taul_int_acy,dx,dy,beta_min,boundaries,lateral_bc)
+        ! Energy-formulation analogue of linear_solver_matrix_ssa_ac_csr_2D.
+        ! Same argument list so the two assemblers are interchangeable from the
+        ! Picard loop. Assembles K (SPD) and b such that K · [u; v] = b.
+
+        implicit none
+
+        type(linear_solver_class), intent(INOUT) :: lgs
+        real(wp), intent(IN) :: ux(:,:)                 ! [m yr^-1] horizontal velocity x (acx-nodes)
+        real(wp), intent(IN) :: uy(:,:)                 ! [m yr^-1] horizontal velocity y (acy-nodes)
+        real(wp), intent(IN) :: beta_acx(:,:)           ! [Pa yr m^-1] basal friction (acx-nodes)
+        real(wp), intent(IN) :: beta_acy(:,:)           ! [Pa yr m^-1] basal friction (acy-nodes)
+        real(wp), intent(IN) :: N_aa(:,:)               ! [Pa yr m] vertically integrated viscosity (aa-nodes)
+        integer,  intent(IN) :: ssa_mask_acx(:,:)       ! [--] ssa solver action mask (acx-nodes)
+        integer,  intent(IN) :: ssa_mask_acy(:,:)       ! [--] ssa solver action mask (acy-nodes)
+        integer,  intent(IN) :: mask_frnt(:,:)          ! [--] ice-front mask
+        real(wp), intent(IN) :: H_ice(:,:)              ! [m]  ice thickness (aa-nodes)
+        real(wp), intent(IN) :: f_ice(:,:)
+        real(wp), intent(IN) :: taud_acx(:,:)           ! [Pa] driving stress (acx-nodes)
+        real(wp), intent(IN) :: taud_acy(:,:)           ! [Pa] driving stress (acy-nodes)
+        real(wp), intent(IN) :: taul_int_acx(:,:)       ! [Pa m] vertically integrated lateral stress (acx-nodes)
+        real(wp), intent(IN) :: taul_int_acy(:,:)       ! [Pa m] vertically integrated lateral stress (acy-nodes)
+        real(wp), intent(IN) :: dx, dy
+        real(wp), intent(IN) :: beta_min                ! [Pa yr m^-1] minimum allowed basal friction
+        character(len=*), intent(IN) :: boundaries
+        character(len=*), intent(IN) :: lateral_bc
+
+        ! Local variables
+        integer  :: nx, ny
+        integer  :: i, j, k, n
+        integer  :: nc, nr
+        integer  :: im1, ip1, jm1, jp1
+        real(wp) :: dxdy
+        real(wp) :: dyodx, dxody          ! dy/dx and dx/dy (recurring stencil prefactors)
+        real(wp) :: beta_now
+        real(wp), allocatable :: N_ab(:,:)
+
+        ! Boundary conditions counterclockwise unit circle:
+        ! 1: x, right border; 2: y, upper; 3: x, left; 4: y, lower
+        character(len=56) :: bcs(4)
+
+        nx = size(H_ice,1)
+        ny = size(H_ice,2)
+
+        ! Initialise the lgs object if needed (n_terms=9 matches the residual assembler)
+        if (.not. allocated(lgs%x_value)) then
+            call linear_solver_init(lgs,nx,ny,nvar=2,n_terms=9)
+        end if
+
+        ! Define border conditions (only choices: no-slip, free-slip, periodic)
+        select case(trim(boundaries))
+            case("MISMIP3D")
+                bcs(1) = "free-slip"; bcs(2) = "periodic"
+                bcs(3) = "no-slip";   bcs(4) = "periodic"
+            case("TROUGH")
+                bcs(1) = "free-slip"; bcs(2) = "periodic"
+                bcs(3) = "no-slip";   bcs(4) = "periodic"
+            case("periodic")
+                bcs(1:4) = "periodic"
+            case("periodic-x")
+                bcs(1) = "periodic";  bcs(2) = "free-slip"
+                bcs(3) = "periodic";  bcs(4) = "free-slip"
+            case("periodic-y")
+                bcs(1) = "free-slip"; bcs(2) = "periodic"
+                bcs(3) = "free-slip"; bcs(4) = "periodic"
+            case("infinite")
+                bcs(1:4) = "free-slip"
+            case("zeros")
+                bcs(1:4) = "no-slip"
+            case DEFAULT
+                bcs(1:4) = "no-slip"
+        end select
+
+        allocate(N_ab(nx,ny))
+
+        ! Stencil prefactors (cell area times inverse spacings)
+        dxdy  = dx * dy
+        dyodx = dy / dx
+        dxody = dx / dy
+
+        ! Stagger depth-integrated viscosity to ab-nodes
+        call stagger_visc_aa_ab(N_ab,N_aa,H_ice,f_ice,boundaries)
+
+        !-------- Assembly of K · [u; v] = b in compressed-sparse-row format --------
+
+        lgs%a_ptr(1) = 1
+        k = 0
+
+        do n = 1, lgs%nmax-1, 2
+
+            i = lgs%n2i((n+1)/2)
+            j = lgs%n2j((n+1)/2)
+
+            ! Periodic neighbour indices (other BC types handled below)
+            im1 = i-1; if (im1 .eq. 0)    im1 = nx
+            ip1 = i+1; if (ip1 .eq. nx+1) ip1 = 1
+            jm1 = j-1; if (jm1 .eq. 0)    jm1 = ny
+            jp1 = j+1; if (jp1 .eq. ny+1) jp1 = 1
+
+            ! ============================================================
+            ! Equation for ux at acx-node (i,j)
+            ! ============================================================
+
+            nr = n   ! row counter
+
+            if (ssa_mask_acx(i,j) .eq. 0) then
+                ! Dirichlet: u = 0. Penalty form (κ on diagonal => K·u = 0 at this row).
+                k = k+1
+                lgs%a_value(k) = 1.0_wp
+                lgs%a_index(k) = nr
+                lgs%b_value(nr) = 0.0_wp
+                lgs%x_value(nr) = 0.0_wp
+
+            else if (ssa_mask_acx(i,j) .eq. -1) then
+                ! Dirichlet to prescribed value.
+                k = k+1
+                lgs%a_value(k) = 1.0_wp
+                lgs%a_index(k) = nr
+                lgs%b_value(nr) = ux(i,j)
+                lgs%x_value(nr) = ux(i,j)
+
+            else if (i .eq. 1 .and. trim(bcs(3)) .ne. "periodic") then
+                ! Left domain boundary
+                if (trim(bcs(3)) .eq. "free-slip") then
+                    nc = 2*lgs%ij2n(i,j)-1                 ! ux(i,j)
+                    k = k+1
+                    lgs%a_value(k) =  1.0_wp; lgs%a_index(k) = nc
+                    nc = 2*lgs%ij2n(ip1,j)-1               ! ux(ip1,j)
+                    k = k+1
+                    lgs%a_value(k) = -1.0_wp; lgs%a_index(k) = nc
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = ux(i,j)
+                else                                       ! no-slip
+                    k = k+1
+                    lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = 0.0_wp
+                end if
+
+            else if (i .eq. nx .and. trim(bcs(1)) .ne. "periodic") then
+                ! Right domain boundary
+                if (trim(bcs(1)) .eq. "free-slip") then
+                    nc = 2*lgs%ij2n(i,j)-1                 ! ux(i,j)
+                    k = k+1
+                    lgs%a_value(k) =  1.0_wp; lgs%a_index(k) = nc
+                    nc = 2*lgs%ij2n(nx-1,j)-1              ! ux(nx-1,j)
+                    k = k+1
+                    lgs%a_value(k) = -1.0_wp; lgs%a_index(k) = nc
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = ux(i,j)
+                else
+                    k = k+1
+                    lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = 0.0_wp
+                end if
+
+            else if (j .eq. 1 .and. trim(bcs(4)) .ne. "periodic") then
+                ! Lower domain boundary
+                if (trim(bcs(4)) .eq. "free-slip") then
+                    nc = 2*lgs%ij2n(i,j)-1
+                    k = k+1
+                    lgs%a_value(k) =  1.0_wp; lgs%a_index(k) = nc
+                    nc = 2*lgs%ij2n(i,jp1)-1
+                    k = k+1
+                    lgs%a_value(k) = -1.0_wp; lgs%a_index(k) = nc
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = ux(i,j)
+                else
+                    k = k+1
+                    lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = 0.0_wp
+                end if
+
+            else if (j .eq. ny .and. trim(bcs(2)) .ne. "periodic") then
+                ! Upper domain boundary
+                if (trim(bcs(2)) .eq. "free-slip") then
+                    nc = 2*lgs%ij2n(i,j)-1
+                    k = k+1
+                    lgs%a_value(k) =  1.0_wp; lgs%a_index(k) = nc
+                    nc = 2*lgs%ij2n(i,ny-1)-1
+                    k = k+1
+                    lgs%a_value(k) = -1.0_wp; lgs%a_index(k) = nc
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = ux(i,j)
+                else
+                    k = k+1
+                    lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = 0.0_wp
+                end if
+
+            else
+                ! Inner ac-node OR lateral boundary (mask=3): use the energy interior stencil.
+                !
+                ! The membrane contributions from the ice-free side vanish naturally because
+                ! N_aa(neighbour)=0 there. The calving-front stress enters as a linear
+                ! boundary-work term in b only (added below if mask=3).
+
+                beta_now = beta_acx(i,j)
+                if (ssa_mask_acx(i,j) .eq. 1 .and. beta_acx(i,j) .eq. 0.0_wp) beta_now = beta_min
+
+                ! -- ux self terms --
+
+                nc = 2*lgs%ij2n(i,j)-1                                 ! ux(i,j)  [diagonal]
+                k = k+1
+                lgs%a_value(k) =  4.0_wp*dyodx*(N_aa(i,j)+N_aa(ip1,j)) &
+                                + dxody*(N_ab(i,j)+N_ab(i,jm1))         &
+                                + beta_now*dxdy
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(ip1,j)-1                                ! ux(ip1,j)
+                k = k+1
+                lgs%a_value(k) = -4.0_wp*dyodx*N_aa(ip1,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(im1,j)-1                                ! ux(im1,j)
+                k = k+1
+                lgs%a_value(k) = -4.0_wp*dyodx*N_aa(i,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(i,jp1)-1                                ! ux(i,jp1)
+                k = k+1
+                lgs%a_value(k) = -dxody*N_ab(i,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(i,jm1)-1                                ! ux(i,jm1)
+                k = k+1
+                lgs%a_value(k) = -dxody*N_ab(i,jm1)
+                lgs%a_index(k) = nc
+
+                ! -- uy cross terms --
+
+                nc = 2*lgs%ij2n(i,j)                                    ! uy(i,j)
+                k = k+1
+                lgs%a_value(k) =  2.0_wp*N_aa(i,j) + N_ab(i,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(ip1,j)                                  ! uy(ip1,j)
+                k = k+1
+                lgs%a_value(k) = -2.0_wp*N_aa(ip1,j) - N_ab(i,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(ip1,jm1)                                ! uy(ip1,jm1)
+                k = k+1
+                lgs%a_value(k) =  2.0_wp*N_aa(ip1,j) + N_ab(i,jm1)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(i,jm1)                                  ! uy(i,jm1)
+                k = k+1
+                lgs%a_value(k) = -2.0_wp*N_aa(i,j) - N_ab(i,jm1)
+                lgs%a_index(k) = nc
+
+                ! Right-hand side: driving stress + (optional) calving-front boundary work
+                lgs%b_value(nr) = -taud_acx(i,j)*dxdy
+                if (ssa_mask_acx(i,j) .eq. 3) then
+                    lgs%b_value(nr) = lgs%b_value(nr) + taul_int_acx(i,j)*dy
+                end if
+                lgs%x_value(nr) = ux(i,j)
+
+            end if
+
+            lgs%a_ptr(nr+1) = k+1
+
+            ! ============================================================
+            ! Equation for uy at acy-node (i,j)
+            ! ============================================================
+
+            nr = n+1   ! row counter
+
+            if (ssa_mask_acy(i,j) .eq. 0) then
+                k = k+1
+                lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                lgs%b_value(nr) = 0.0_wp
+                lgs%x_value(nr) = 0.0_wp
+
+            else if (ssa_mask_acy(i,j) .eq. -1) then
+                k = k+1
+                lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                lgs%b_value(nr) = uy(i,j)
+                lgs%x_value(nr) = uy(i,j)
+
+            else if (j .eq. 1 .and. trim(bcs(4)) .ne. "periodic") then
+                if (trim(bcs(4)) .eq. "free-slip") then
+                    nc = 2*lgs%ij2n(i,j)
+                    k = k+1
+                    lgs%a_value(k) =  1.0_wp; lgs%a_index(k) = nc
+                    nc = 2*lgs%ij2n(i,jp1)
+                    k = k+1
+                    lgs%a_value(k) = -1.0_wp; lgs%a_index(k) = nc
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = uy(i,j)
+                else
+                    k = k+1
+                    lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = 0.0_wp
+                end if
+
+            else if (j .eq. ny .and. trim(bcs(2)) .ne. "periodic") then
+                if (trim(bcs(2)) .eq. "free-slip") then
+                    nc = 2*lgs%ij2n(i,j)
+                    k = k+1
+                    lgs%a_value(k) =  1.0_wp; lgs%a_index(k) = nc
+                    nc = 2*lgs%ij2n(i,ny-1)
+                    k = k+1
+                    lgs%a_value(k) = -1.0_wp; lgs%a_index(k) = nc
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = uy(i,j)
+                else
+                    k = k+1
+                    lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = 0.0_wp
+                end if
+
+            else if (i .eq. 1 .and. trim(bcs(3)) .ne. "periodic") then
+                if (trim(bcs(3)) .eq. "free-slip") then
+                    nc = 2*lgs%ij2n(i,j)
+                    k = k+1
+                    lgs%a_value(k) =  1.0_wp; lgs%a_index(k) = nc
+                    nc = 2*lgs%ij2n(ip1,j)
+                    k = k+1
+                    lgs%a_value(k) = -1.0_wp; lgs%a_index(k) = nc
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = uy(i,j)
+                else
+                    k = k+1
+                    lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = 0.0_wp
+                end if
+
+            else if (i .eq. nx .and. trim(bcs(1)) .ne. "periodic") then
+                if (trim(bcs(1)) .eq. "free-slip") then
+                    nc = 2*lgs%ij2n(i,j)
+                    k = k+1
+                    lgs%a_value(k) =  1.0_wp; lgs%a_index(k) = nc
+                    nc = 2*lgs%ij2n(nx-1,j)
+                    k = k+1
+                    lgs%a_value(k) = -1.0_wp; lgs%a_index(k) = nc
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = uy(i,j)
+                else
+                    k = k+1
+                    lgs%a_value(k) = 1.0_wp; lgs%a_index(k) = nr
+                    lgs%b_value(nr) = 0.0_wp
+                    lgs%x_value(nr) = 0.0_wp
+                end if
+
+            else
+                ! Inner ac-node OR lateral boundary (mask=3): energy interior stencil.
+
+                beta_now = beta_acy(i,j)
+                if (ssa_mask_acy(i,j) .eq. 1 .and. beta_acy(i,j) .eq. 0.0_wp) beta_now = beta_min
+
+                ! -- uy self terms --
+
+                nc = 2*lgs%ij2n(i,j)                                    ! uy(i,j)  [diagonal]
+                k = k+1
+                lgs%a_value(k) =  4.0_wp*dxody*(N_aa(i,j)+N_aa(i,jp1)) &
+                                + dyodx*(N_ab(i,j)+N_ab(im1,j))         &
+                                + beta_now*dxdy
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(i,jp1)                                  ! uy(i,jp1)
+                k = k+1
+                lgs%a_value(k) = -4.0_wp*dxody*N_aa(i,jp1)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(i,jm1)                                  ! uy(i,jm1)
+                k = k+1
+                lgs%a_value(k) = -4.0_wp*dxody*N_aa(i,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(ip1,j)                                  ! uy(ip1,j)
+                k = k+1
+                lgs%a_value(k) = -dyodx*N_ab(i,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(im1,j)                                  ! uy(im1,j)
+                k = k+1
+                lgs%a_value(k) = -dyodx*N_ab(im1,j)
+                lgs%a_index(k) = nc
+
+                ! -- ux cross terms --
+
+                nc = 2*lgs%ij2n(i,j)-1                                  ! ux(i,j)
+                k = k+1
+                lgs%a_value(k) =  2.0_wp*N_aa(i,j) + N_ab(i,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(i,jp1)-1                                ! ux(i,jp1)
+                k = k+1
+                lgs%a_value(k) = -2.0_wp*N_aa(i,jp1) - N_ab(i,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(im1,jp1)-1                              ! ux(im1,jp1)
+                k = k+1
+                lgs%a_value(k) =  2.0_wp*N_aa(i,jp1) + N_ab(im1,j)
+                lgs%a_index(k) = nc
+
+                nc = 2*lgs%ij2n(im1,j)-1                                ! ux(im1,j)
+                k = k+1
+                lgs%a_value(k) = -2.0_wp*N_aa(i,j) - N_ab(im1,j)
+                lgs%a_index(k) = nc
+
+                lgs%b_value(nr) = -taud_acy(i,j)*dxdy
+                if (ssa_mask_acy(i,j) .eq. 3) then
+                    lgs%b_value(nr) = lgs%b_value(nr) + taul_int_acy(i,j)*dx
+                end if
+                lgs%x_value(nr) = uy(i,j)
+
+            end if
+
+            lgs%a_ptr(nr+1) = k+1
+
+        end do
+
+        return
+
+    end subroutine linear_solver_matrix_ssa_ac_csr_2D_energy
+
+end module solver_ssa_ac_energy

--- a/src/physics/velocity_diva.f90
+++ b/src/physics/velocity_diva.f90
@@ -5,9 +5,10 @@ module velocity_diva
                     integrate_trapezoid1D_1D, integrate_trapezoid1D_pt, minmax
 
     use deformation, only : calc_strain_rate_horizontal_2D
-    use basal_dragging 
+    use basal_dragging
     use solver_ssa_ac
-    use solver_linear 
+    use solver_ssa_ac_energy, only : linear_solver_matrix_ssa_ac_csr_2D_energy
+    use solver_linear
     use velocity_general, only : set_inactive_margins, &
                         picard_calc_error, picard_calc_error_angle,  &
                         picard_relax_vel, picard_relax_visc, &
@@ -23,7 +24,8 @@ module velocity_diva
 
     type diva_param_class
 
-        character(len=256) :: ssa_lis_opt 
+        character(len=56)  :: ssa_solver        ! "residual" | "energy"
+        character(len=256) :: ssa_lis_opt
         character(len=256) :: ssa_lateral_bc
         character(len=256) :: boundaries 
         character(len=256) :: glf_method 
@@ -311,9 +313,18 @@ if (.FALSE.) then
 end if 
             
             ! Populate ssa matrices Ax=b
-            call linear_solver_matrix_ssa_ac_csr_2D(lgs_now,ux_bar,uy_bar,beta_eff_acx,beta_eff_acy,visc_eff_int,  &
+            select case(trim(par%ssa_solver))
+                case("energy")
+                    ! Symmetric positive-definite Hessian of the SSA energy density (CG/AMG-friendly).
+                    call linear_solver_matrix_ssa_ac_csr_2D_energy(lgs_now,ux_bar,uy_bar,beta_eff_acx,beta_eff_acy,visc_eff_int,  &
                                 ssa_mask_acx,ssa_mask_acy,mask_frnt,H_ice,f_ice,taud_acx,taud_acy, &
                                 taul_int_acx,taul_int_acy,dx,dy,par%beta_min,par%boundaries,par%ssa_lateral_bc)
+                case DEFAULT
+                    ! Original Larour-style residual formulation.
+                    call linear_solver_matrix_ssa_ac_csr_2D(lgs_now,ux_bar,uy_bar,beta_eff_acx,beta_eff_acy,visc_eff_int,  &
+                                ssa_mask_acx,ssa_mask_acy,mask_frnt,H_ice,f_ice,taud_acx,taud_acy, &
+                                taul_int_acx,taul_int_acy,dx,dy,par%beta_min,par%boundaries,par%ssa_lateral_bc)
+            end select
 
             ! Solve linear equation
             call linear_solver_matrix_solve(lgs_now,par%ssa_lis_opt)

--- a/src/physics/velocity_ssa.f90
+++ b/src/physics/velocity_ssa.f90
@@ -7,8 +7,9 @@ module velocity_ssa
                     integrate_trapezoid1D_1D, integrate_trapezoid1D_pt, minmax
 
     use deformation, only : calc_strain_rate_horizontal_2D
-    use basal_dragging 
+    use basal_dragging
     use solver_ssa_ac
+    use solver_ssa_ac_energy, only : linear_solver_matrix_ssa_ac_csr_2D_energy
     use solver_linear
     use velocity_general, only : set_inactive_margins, &
                         picard_calc_error, picard_calc_error_angle, &
@@ -24,9 +25,10 @@ module velocity_ssa
 
     type ssa_param_class
 
+        character(len=56)  :: ssa_solver        ! "residual" | "energy"
         character(len=256) :: ssa_lis_opt
-        character(len=256) :: ssa_lateral_bc 
-        character(len=256) :: boundaries  
+        character(len=256) :: ssa_lateral_bc
+        character(len=256) :: boundaries
         integer  :: visc_method
         real(wp) :: visc_const
         integer  :: beta_method
@@ -242,9 +244,18 @@ if (.TRUE.) then
 ! ajr: set to False to impose fixed velocity solution (stream-s06 testing)!!
             
             ! Populate ssa matrices Ax=b
-            call linear_solver_matrix_ssa_ac_csr_2D(lgs_now,ux_b,uy_b,beta_acx,beta_acy,visc_eff_int,  &
+            select case(trim(par%ssa_solver))
+                case("energy")
+                    ! Symmetric positive-definite Hessian of the SSA energy density (CG/AMG-friendly).
+                    call linear_solver_matrix_ssa_ac_csr_2D_energy(lgs_now,ux_b,uy_b,beta_acx,beta_acy,visc_eff_int,  &
                                 ssa_mask_acx,ssa_mask_acy,mask_frnt,H_ice,f_ice,taud_acx,taud_acy,  &
                                 taul_int_acx,taul_int_acy,dx,dy,par%beta_min,par%boundaries,par%ssa_lateral_bc)
+                case DEFAULT
+                    ! Original Larour-style residual formulation.
+                    call linear_solver_matrix_ssa_ac_csr_2D(lgs_now,ux_b,uy_b,beta_acx,beta_acy,visc_eff_int,  &
+                                ssa_mask_acx,ssa_mask_acy,mask_frnt,H_ice,f_ice,taud_acx,taud_acy,  &
+                                taul_int_acx,taul_int_acy,dx,dy,par%beta_min,par%boundaries,par%ssa_lateral_bc)
+            end select
 
             ! Solve linear equation
             call linear_solver_matrix_solve(lgs_now,par%ssa_lis_opt)

--- a/src/yelmo_defs.f90
+++ b/src/yelmo_defs.f90
@@ -384,7 +384,9 @@ module yelmo_defs
         real(wp)   :: eps_0                 ! Minimum assumed strain rate for effective viscosity regularization
         integer    :: scale_T
         real(wp)   :: T_frz
-        character(len=256) :: ssa_lis_opt 
+        character(len=56)  :: ssa_solver           ! "residual" (default) | "energy"
+        character(len=256) :: ssa_lis_opt_residual ! LIS solver options for residual formulation
+        character(len=256) :: ssa_lis_opt_energy   ! LIS solver options for energy formulation (SPD => CG/AMG)
         character(len=56)  :: ssa_lat_bc
         real(wp)   :: ssa_beta_max          ! Maximum value of beta for which ssa should be calculated
         real(wp)   :: ssa_vel_max

--- a/src/yelmo_dynamics.f90
+++ b/src/yelmo_dynamics.f90
@@ -369,9 +369,15 @@ contains
                 maxval(dyn%now%ssa_mask_acx+dyn%now%ssa_mask_acy) .gt. 0) then 
             ! Calculate SSA as normal 
 
-            ! Set diva parameters from Yelmo settings 
-            ssa_par%ssa_lis_opt    = dyn%par%ssa_lis_opt 
-            ssa_par%boundaries     = dyn%par%boundaries  
+            ! Set diva parameters from Yelmo settings
+            ssa_par%ssa_solver     = dyn%par%ssa_solver
+            select case(trim(dyn%par%ssa_solver))
+                case("energy")
+                    ssa_par%ssa_lis_opt = dyn%par%ssa_lis_opt_energy
+                case DEFAULT
+                    ssa_par%ssa_lis_opt = dyn%par%ssa_lis_opt_residual
+            end select
+            ssa_par%boundaries     = dyn%par%boundaries
             ssa_par%ssa_lateral_bc = dyn%par%ssa_lat_bc  
             ssa_par%visc_method    = dyn%par%visc_method 
             ssa_par%visc_const     = dyn%par%visc_const 
@@ -499,9 +505,15 @@ contains
         ! dyn%now%ssa_mask_acy = 0_wp 
         ! dyn%now%uy_bar = 0.0_wp 
 
-        ! Set diva parameters from Yelmo settings 
-        diva_par%ssa_lis_opt    = dyn%par%ssa_lis_opt 
-        diva_par%boundaries     = dyn%par%boundaries 
+        ! Set diva parameters from Yelmo settings
+        diva_par%ssa_solver     = dyn%par%ssa_solver
+        select case(trim(dyn%par%ssa_solver))
+            case("energy")
+                diva_par%ssa_lis_opt = dyn%par%ssa_lis_opt_energy
+            case DEFAULT
+                diva_par%ssa_lis_opt = dyn%par%ssa_lis_opt_residual
+        end select
+        diva_par%boundaries     = dyn%par%boundaries
         diva_par%ssa_lateral_bc = dyn%par%ssa_lat_bc 
         diva_par%no_slip        = no_slip 
         diva_par%visc_method    = dyn%par%visc_method 
@@ -587,9 +599,10 @@ contains
         call set_ssa_masks(dyn%now%ssa_mask_acx,dyn%now%ssa_mask_acy,tpo%now%mask_frnt,tpo%now%H_ice,tpo%now%f_ice, &
                     tpo%now%f_grnd,tpo%now%z_base,bnd%z_sl,dyn%par%dx,use_ssa=.TRUE.,lateral_bc=dyn%par%ssa_lat_bc)
 
-        ! Set diva parameters from Yelmo settings 
-        l1l2_par%ssa_lis_opt    = dyn%par%ssa_lis_opt 
-        l1l2_par%ssa_lateral_bc = dyn%par%ssa_lat_bc 
+        ! Set diva parameters from Yelmo settings
+        ! Note: L1L2 always uses the residual SSA assembler for now (energy form is SSA-only).
+        l1l2_par%ssa_lis_opt    = dyn%par%ssa_lis_opt_residual
+        l1l2_par%ssa_lateral_bc = dyn%par%ssa_lat_bc
         l1l2_par%boundaries     = dyn%par%boundaries 
         l1l2_par%no_slip        = no_slip 
         l1l2_par%visc_method    = dyn%par%visc_method 
@@ -1050,8 +1063,13 @@ contains
         call nml_read(filename,group_ydyn,"eps_0",              par%eps_0,              init=init_pars)
         call nml_read(filename,group_ydyn,"scale_T",            par%scale_T,            init=init_pars)
         call nml_read(filename,group_ydyn,"T_frz",              par%T_frz,              init=init_pars)
-        call nml_read(filename,group_ydyn,"ssa_lis_opt",        par%ssa_lis_opt,        init=init_pars)
+        call nml_read(filename,group_ydyn,"ssa_solver",         par%ssa_solver,         init=init_pars)
+        call nml_read(filename,group_ydyn,"ssa_lis_opt_residual",par%ssa_lis_opt_residual,init=init_pars)
+        call nml_read(filename,group_ydyn,"ssa_lis_opt_energy", par%ssa_lis_opt_energy, init=init_pars)
         call nml_read(filename,group_ydyn,"ssa_lat_bc",         par%ssa_lat_bc,         init=init_pars)
+
+        ! Apply default for ssa_solver if not set in namelist
+        if (trim(par%ssa_solver) .eq. "") par%ssa_solver = "residual"
         call nml_read(filename,group_ydyn,"ssa_beta_max",       par%ssa_beta_max,       init=init_pars)
         call nml_read(filename,group_ydyn,"ssa_vel_max",        par%ssa_vel_max,        init=init_pars)
         call nml_read(filename,group_ydyn,"ssa_iter_max",       par%ssa_iter_max,       init=init_pars)

--- a/tests/test_ssa_energy.f90
+++ b/tests/test_ssa_energy.f90
@@ -1,0 +1,177 @@
+program test_ssa_energy
+    ! Standalone validation: confirm that the energy SSA assembler satisfies
+    ! the algebraic identity
+    !
+    !     K_inner = - A_residual_inner * dx * dy
+    !     b_inner = - taud_inner       * dx * dy
+    !
+    ! against the residual assembler in solver_ssa_ac.f90, on a small synthetic
+    ! grid with periodic boundaries (so every cell is "inner").
+    !
+    ! Pass criterion: max relative error in K and absolute error in b smaller
+    ! than tol. No solver call is made — this is a pure assembler-equivalence
+    ! check, independent of LIS.
+
+    use yelmo_defs, only : wp
+    use solver_linear, only : linear_solver_class
+    use solver_ssa_ac, only : linear_solver_matrix_ssa_ac_csr_2D
+    use solver_ssa_ac_energy, only : linear_solver_matrix_ssa_ac_csr_2D_energy
+
+    implicit none
+
+    integer, parameter :: nx = 8, ny = 8
+    real(wp), parameter :: dx = 5000.0_wp, dy = 5000.0_wp     ! [m]
+    real(wp), parameter :: beta_min = 0.0_wp
+    ! Yelmo's working precision is single (wp = sp), so the two assemblers'
+    ! operation-order differences produce ~1e-7 relative roundoff between the
+    ! algebraically-identical entries. Tolerate that — anything larger is a
+    ! real stencil/sign bug.
+    real(wp), parameter :: rtol   = 1.0e-5_wp
+    real(wp), parameter :: atol_K = 1.0_wp                    ! absolute fallback for tiny K entries
+    real(wp), parameter :: atol_b = 1.0e-3_wp
+
+    real(wp) :: ux(nx,ny), uy(nx,ny)
+    real(wp) :: beta_acx(nx,ny), beta_acy(nx,ny)
+    real(wp) :: N_aa(nx,ny)
+    integer  :: ssa_mask_acx(nx,ny), ssa_mask_acy(nx,ny)
+    integer  :: mask_frnt(nx,ny)
+    real(wp) :: H_ice(nx,ny), f_ice(nx,ny)
+    real(wp) :: taud_acx(nx,ny), taud_acy(nx,ny)
+    real(wp) :: taul_int_acx(nx,ny), taul_int_acy(nx,ny)
+
+    type(linear_solver_class) :: lgs_res, lgs_eng
+
+    real(wp) :: dxdy
+    real(wp) :: K_val, A_val, expected, diff, rel_err
+    real(wp) :: max_K_rel_err, max_K_abs_err, max_b_abs_err
+    integer  :: nr, nc, idx
+    integer  :: i, j
+    integer  :: K_fail_count, b_fail_count
+    logical  :: passed
+
+    dxdy = dx * dy
+
+    ! ---- Build a synthetic (but plausible) input state ----
+    !
+    ! Use spatially varying viscosity, drag, and driving stress so that the
+    ! identity check exercises every coefficient pattern.
+    do j = 1, ny
+    do i = 1, nx
+        H_ice(i,j)        = 1000.0_wp + 50.0_wp*sin(real(i,wp)) + 30.0_wp*cos(real(j,wp))
+        f_ice(i,j)        = 1.0_wp
+        N_aa(i,j)         = 1.0e10_wp * (1.0_wp + 0.2_wp*sin(0.5_wp*real(i,wp))*cos(0.5_wp*real(j,wp)))
+        beta_acx(i,j)     = 1.0e3_wp * (1.0_wp + 0.1_wp*real(i,wp))
+        beta_acy(i,j)     = 1.0e3_wp * (1.0_wp + 0.1_wp*real(j,wp))
+        taud_acx(i,j)     = -5.0e4_wp + 1.0e3_wp*real(i+j,wp)
+        taud_acy(i,j)     = -3.0e4_wp + 5.0e2_wp*real(i-j,wp)
+        ux(i,j)           = 10.0_wp + 0.5_wp*real(i,wp)
+        uy(i,j)           = 5.0_wp  + 0.3_wp*real(j,wp)
+        taul_int_acx(i,j) = 0.0_wp                ! no calving front in periodic test
+        taul_int_acy(i,j) = 0.0_wp
+        mask_frnt(i,j)    = 0
+        ssa_mask_acx(i,j) = 1                     ! interior SSA solve everywhere
+        ssa_mask_acy(i,j) = 1
+    end do
+    end do
+
+    ! ---- Assemble both matrices ----
+    call linear_solver_matrix_ssa_ac_csr_2D(lgs_res,ux,uy,beta_acx,beta_acy,N_aa, &
+                ssa_mask_acx,ssa_mask_acy,mask_frnt,H_ice,f_ice,taud_acx,taud_acy, &
+                taul_int_acx,taul_int_acy,dx,dy,beta_min,"periodic","none")
+
+    call linear_solver_matrix_ssa_ac_csr_2D_energy(lgs_eng,ux,uy,beta_acx,beta_acy,N_aa, &
+                ssa_mask_acx,ssa_mask_acy,mask_frnt,H_ice,f_ice,taud_acx,taud_acy, &
+                taul_int_acx,taul_int_acy,dx,dy,beta_min,"periodic","none")
+
+    ! ---- Compare matrices entry-by-entry ----
+    !
+    ! Both assemblers use the same CSR ordering (same loop, same sparsity
+    ! pattern), so we can step through a_value side-by-side.
+    max_K_rel_err = 0.0_wp
+    max_K_abs_err = 0.0_wp
+    K_fail_count  = 0
+
+    if (lgs_res%a_ptr(lgs_res%nmax+1) /= lgs_eng%a_ptr(lgs_eng%nmax+1)) then
+        write(*,*) "FAIL: differing nnz between residual and energy assembler"
+        write(*,*) "  residual nnz =", lgs_res%a_ptr(lgs_res%nmax+1)-1
+        write(*,*) "  energy   nnz =", lgs_eng%a_ptr(lgs_eng%nmax+1)-1
+        stop 1
+    end if
+
+    do nr = 1, lgs_res%nmax
+        do idx = lgs_res%a_ptr(nr), lgs_res%a_ptr(nr+1)-1
+            nc = lgs_res%a_index(idx)
+
+            ! Sanity: same column index in same slot (same sparsity pattern)
+            if (lgs_eng%a_index(idx) /= nc) then
+                write(*,*) "FAIL: column index mismatch at row ", nr, " slot ", idx
+                stop 1
+            end if
+
+            A_val    = real(lgs_res%a_value(idx), wp)
+            K_val    = real(lgs_eng%a_value(idx), wp)
+            expected = -A_val * dxdy
+            diff     = K_val - expected
+
+            if (abs(expected) > 0.0_wp) then
+                rel_err = abs(diff) / abs(expected)
+            else
+                rel_err = abs(diff)
+            end if
+
+            if (rel_err > max_K_rel_err) max_K_rel_err = rel_err
+            if (abs(diff) > max_K_abs_err) max_K_abs_err = abs(diff)
+
+            if (rel_err > rtol .and. abs(diff) > atol_K) then
+                K_fail_count = K_fail_count + 1
+                if (K_fail_count <= 5) then
+                    write(*,'(a,i6,a,i6,a,3es14.6)') "  K mismatch nr=", nr, &
+                            " nc=", nc, &
+                            " (K, -A*dxdy, diff) = ", K_val, expected, diff
+                end if
+            end if
+        end do
+    end do
+
+    ! ---- Compare RHS ----
+    max_b_abs_err = 0.0_wp
+    b_fail_count  = 0
+    do nr = 1, lgs_res%nmax
+        expected = -real(lgs_res%b_value(nr), wp) * dxdy
+        diff     = real(lgs_eng%b_value(nr), wp) - expected
+        if (abs(diff) > max_b_abs_err) max_b_abs_err = abs(diff)
+        if (abs(diff) > atol_b) then
+            b_fail_count = b_fail_count + 1
+            if (b_fail_count <= 5) then
+                write(*,'(a,i6,a,3es14.6)') "  b mismatch nr=", nr, &
+                        " (b_eng, -b_res*dxdy, diff) = ", &
+                        real(lgs_eng%b_value(nr), wp), expected, diff
+            end if
+        end if
+    end do
+
+    ! ---- Report ----
+    write(*,*) "==============================================="
+    write(*,*) " SSA energy-vs-residual algebraic-identity test"
+    write(*,*) "==============================================="
+    write(*,'(a,2(1x,i0))')   "  grid (nx,ny)     :", nx, ny
+    write(*,'(a,2(1x,es10.3))')"  (dx,dy)          :", dx, dy
+    write(*,'(a,1x,i0)')      "  total rows       :", lgs_res%nmax
+    write(*,'(a,1x,i0)')      "  total nnz        :", lgs_res%a_ptr(lgs_res%nmax+1)-1
+    write(*,*)
+    write(*,'(a,es12.4)')     "  max K rel err    :", max_K_rel_err
+    write(*,'(a,es12.4)')     "  max K abs err    :", max_K_abs_err
+    write(*,'(a,es12.4)')     "  max b abs err    :", max_b_abs_err
+    write(*,'(a,i0)')         "  K mismatches     :", K_fail_count
+    write(*,'(a,i0)')         "  b mismatches     :", b_fail_count
+    write(*,*)
+
+    passed = (K_fail_count == 0) .and. (b_fail_count == 0)
+    if (passed) then
+        write(*,*) " PASS"
+    else
+        write(*,*) " FAIL"
+        stop 1
+    end if
+
+end program test_ssa_energy


### PR DESCRIPTION
## Summary

- New SSA momentum-balance assembler (`src/physics/solver_ssa_ac_energy.f90`) building the symmetric positive-definite Hessian K of the discrete viscous-energy density. With (η, β, H) frozen per Picard iteration the system is quadratic and CG can replace BiCGStab. Algebraic identity `K_inner = -A_residual_inner * dx*dy` for interior cells.
- Selectable via new `ydyn.ssa_solver = \"residual\" | \"energy\"`. SSA and DIVA both dispatch on it. The old `ssa_lis_opt` namelist parameter is split into `ssa_lis_opt_residual` and `ssa_lis_opt_energy` (defaults `bicgsafe + jacobi` and `cg + jacobi` respectively).
- Calving-front BC encoded as a linear boundary-work term in the RHS rather than a one-sided FD stencil — differs from the residual treatment but more stable on grounded fronts.
- New defaults set `ssa_solver = \"energy\"` in all parameter files; `ssa_lat_bc` switched from `\"floating\"` → `\"all\"` in production files. SLAB-S06 and ISMIPHOM keep `\"slab\"`.
- Algebraic-identity validation: `tests/test_ssa_energy.f90` (build with `make ssa_energy`).

## Performance finding

initmip-grl, GRL-16KM, 100 yr, AB-SAM, `dt_method=0`, `ssa_lat_bc=\"all\"`:

| | residual | energy | ratio |
|---|---|---|---|
| Wall time | 48.9 s | 5.8 s | **8.4× faster** |
| Total Picard iter | 2030 | 135 | 15× fewer |
| uxy_s max (m/yr) | 5424 | 3567 | residual shows runaway velocities at grounded marine fronts |

Energy is essentially insensitive to switching `ssa_lat_bc` between `\"floating\"` and `\"all\"` (uxy_s_max literally identical). Residual is BC-sensitive — applying the lateral BC to grounded fronts triples its Picard work. This supports the prior intuition that the residual one-sided FD discretization of the calving-front BC is deficient.

## Test plan

- [x] Algebraic-identity test passes (`make ssa_energy && libyelmo/bin/test_ssa_energy.x`) — `K_inner = -A * dx*dy` to 1.4e-7 (single-precision roundoff)
- [x] SLAB-S06 (`solver=ssa` and `solver=diva`) smoke runs: residual and energy agree to 9e-6 relative on `ux_bar` (no calving fronts)
- [x] initmip-grl 100yr (residual + energy, `ssa_lat_bc=\"floating\"` and `\"all\"`) — both run to completion, mass conserved
- [ ] **Reviewer note**: numerical results will differ from any pre-existing reference output that used the residual formulation, even on benchmarks where the formulation difference is small. Particularly significant on Greenland/Antarctica with calving fronts.