### PR TITLE
velocity_diva: kind-suffix sweep and OpenMP for calc_visc_eff_3D_aa

### DIFF
--- a/src/physics/velocity_diva.f90
+++ b/src/physics/velocity_diva.f90
@@ -773,18 +773,22 @@ end if
 
         visc_eff = visc_min
 
-        do j = 1, ny 
-        do i = 1, nx 
+        !$omp parallel do collapse(2) private(i,j,k,im1,ip1,jm1,jp1, &
+        !$omp&   dudx_aa,dvdy_aa,dudy_aa_1,dudy_aa_2,dudy_aa, &
+        !$omp&   dvdx_aa_1,dvdx_aa_2,dvdx_aa,duxdz_aa,duydz_aa, &
+        !$omp&   eps_sq_aa,ATT_aa)
+        do j = 1, ny
+        do i = 1, nx
 
-            if ( is_equal(f_ice(i,j),1.0_wp) ) then 
+            if ( is_equal(f_ice(i,j),1.0_wp) ) then
 
                 ! Get neighbor indices
                 call get_neighbor_indices_bc_codes(im1,ip1,jm1,jp1,i,j,nx,ny,BC)
 
                 ! Get strain rate terms
-                dudx_aa = (ux(i,j)-ux(im1,j))/dx 
-                dvdy_aa = (uy(i,j)-uy(i,jm1))/dy 
-                
+                dudx_aa = (ux(i,j)-ux(im1,j))/dx
+                dvdy_aa = (uy(i,j)-uy(i,jm1))/dy
+
                 dudy_aa_1 = (ux(i,jp1)-ux(i,jm1))/(2.0_wp*dy)
                 dudy_aa_2 = (ux(im1,jp1)-ux(im1,jm1))/(2.0_wp*dy)
                 dudy_aa   = 0.5_wp*(dudy_aa_1+dudy_aa_2)
@@ -794,13 +798,13 @@ end if
                 dvdx_aa   = 0.5_wp*(dvdx_aa_1+dvdx_aa_2)
 
                 ! Loop over column
-                do k = 1, nz 
+                do k = 1, nz
 
                     ! Get vertical shear strain rate terms
                     duxdz_aa = 0.5_wp*(duxdz(i,j,k)+duxdz(im1,j,k))
                     duydz_aa = 0.5_wp*(duydz(i,j,k)+duydz(i,jm1,k))
 
-                    ! Calculate the total effective strain rate from L19, Eq. 21 
+                    ! Calculate the total effective strain rate from L19, Eq. 21
                     eps_sq_aa = dudx_aa**2 + dvdy_aa**2 + dudx_aa*dvdy_aa + 0.25_wp*(dudy_aa+dvdx_aa)**2 &
                                 + 0.25_wp*duxdz_aa**2 + 0.25_wp*duydz_aa**2 + eps_0_sq
 
@@ -810,12 +814,13 @@ end if
                     ! Calculate effective viscosity on ab-nodes
                     visc_eff(i,j,k) = 0.5_wp*(eps_sq_aa)**(p1) * ATT_aa**(p2)
 
-                end do 
+                end do
 
-            end if 
+            end if
 
-        end do  
-        end do 
+        end do
+        end do
+        !$omp end parallel do
 
         return 
 

--- a/src/physics/velocity_diva.f90
+++ b/src/physics/velocity_diva.f90
@@ -410,9 +410,9 @@ end if
         !$omp parallel do collapse(2) private(i,j)
         do j = 1, ny 
         do i = 1, nx 
-            if ( is_equal(f_ice(i,j),1.0) ) then 
-                F1(i,j,:) = integrate_trapezoid1D_1D((H_ice(i,j)/visc_eff(i,j,:))*(1.0-zeta_aa),zeta_aa)
-            end if  
+            if ( is_equal(f_ice(i,j),1.0_wp) ) then
+                F1(i,j,:) = integrate_trapezoid1D_1D((H_ice(i,j)/visc_eff(i,j,:))*(1.0_wp-zeta_aa),zeta_aa)
+            end if
         end do
         end do  
         !$omp end parallel do
@@ -585,9 +585,9 @@ end if
         allocate(dvdx(nx,ny,nz))
         allocate(dvdy(nx,ny,nz))
 
-        ! Calculate exponents 
-        p1 = (1.0 - n_glen)/(2.0*n_glen)
-        p2 = -1.0/n_glen
+        ! Calculate exponents
+        p1 = (1.0_wp - n_glen)/(2.0_wp*n_glen)
+        p2 = -1.0_wp/n_glen
 
         ! Calculate squared minimum strain rate 
         eps_0_sq = eps_0*eps_0
@@ -619,7 +619,7 @@ end if
         do j = 1, ny  
         do i = 1, nx
 
-            if (f_ice(i,j) == 1.0) then
+            if ( is_equal(f_ice(i,j),1.0_wp) ) then
 
                 ! Get neighbor indices
                 call get_neighbor_indices_bc_codes(im1,ip1,jm1,jp1,i,j,nx,ny,BC)
@@ -650,7 +650,7 @@ if (.not. use_gq3D) then
                     !ATTn = ATT(i,j,k)
 
                     ! Calculate effective viscosity on nodes and averaged to center aa-node
-                    viscn = 0.5 * (eps_sq_n)**(p1) * ATTn**(p2)
+                    viscn = 0.5_wp * (eps_sq_n)**(p1) * ATTn**(p2)
                     visc(i,j,k) = sum(viscn*gq2d%wt)/gq2d%wt_tot
 
                 end do
@@ -697,7 +697,7 @@ else
                     !ATTn = ATT(i,j,k)
 
                     ! Calculate effective viscosity on nodes and averaged to center aa-node
-                    viscn8 = 0.5 * (eps_sq_n8)**(p1) * ATTn8**(p2)
+                    viscn8 = 0.5_wp * (eps_sq_n8)**(p1) * ATTn8**(p2)
                     visc(i,j,k) = sum(viscn8*gq3d%wt)/gq3d%wt_tot
                 end do
 
@@ -848,7 +848,7 @@ end if
         do j = 1, ny 
         do i = 1, nx
 
-            if ( is_equal(f_ice(i,j),1.0) ) then
+            if ( is_equal(f_ice(i,j),1.0_wp) ) then
                 ! Calculate the vertically averaged viscosity for this point
                 visc_eff_mean = integrate_trapezoid1D_pt(visc_eff(i,j,:),zeta_aa) 
 


### PR DESCRIPTION
## Summary

Two small follow-ups on `src/physics/velocity_diva.f90` from the recent review pass:

- **Kind-suffix sweep + `is_equal` consistency** (`3bcd0d5c`): replaces bare `1.0`/`0.5`/`2.0` literals with `_wp`-suffixed counterparts in `calc_vel_horizontal_3D`, `calc_visc_eff_3D_nodes`, and `calc_visc_eff_int`, and converts the lone `f_ice(i,j) == 1.0` comparison in `calc_visc_eff_3D_nodes` to `is_equal(f_ice(i,j),1.0_wp)`, matching the convention used elsewhere in the file.
- **OpenMP on `calc_visc_eff_3D_aa`** (`d1fe20f5`): adds `!$omp parallel do collapse(2)` to the j/i loop, bringing the routine in line with the OpenMP coverage already present in its sibling routines. All loop-carried scalars are local; outer-loop quantities feed only the inner k loop and write to disjoint `(i,j,:)` columns of `visc_eff`.

No behavioral changes intended — numerical output should be bit-identical apart from the (legitimate) reordering effects of threaded execution in `calc_visc_eff_3D_aa`.

## Test plan

- [ ] Build cleanly (gfortran + ifort if both are in CI).
- [ ] Run a short reference experiment with `visc_method=1` and confirm no regression vs `main`.
- [ ] Run the same experiment with `visc_method=2` (the path that exercises `calc_visc_eff_3D_aa`) and confirm OpenMP parallelization is bit-reproducible at a single thread and well-behaved at multi-thread.