### PR TITLE
Add bnd%mask_ice "mask" boundary type and synthetic test

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -168,6 +168,13 @@ slab : yelmo-static
 		@echo "    yelmo_slab.x is ready."
 		@echo " "
 
+mask_ice : yelmo-static
+		$(FC) $(DFLAGS) $(FFLAGS) $(INC_FESMUTILS) $(INC_LIS) -o $(bindir)/yelmo_mask_ice.x tests/yelmo_mask_ice.f90 \
+			-L${CURDIR}/libyelmo/include -lyelmo $(LFLAGS)
+		@echo " "
+		@echo "    yelmo_mask_ice.x is ready."
+		@echo " "
+
 check_sim :
 		$(FC) $(DFLAGS) $(INC_FESMUTILS) $(FFLAGS) -o ./check_sim.x check_sim.f90 \
 			$(LFLAGS)

--- a/par/yelmo_MASK_ICE.nml
+++ b/par/yelmo_MASK_ICE.nml
@@ -36,13 +36,18 @@
     Q_geo_const     = 50.0              ! [mW/m2] Geothermal heat flux
 
     ! ============================================================
-    ! Border mask (applied uniformly to all four border rings AFTER
-    ! yelmo_init):
-    !    mask_bnd = -1  ->  forced zero ice (ablation)
-    !    mask_bnd =  0  ->  imposed = H_ice_ref (held at initial H_ice)
-    !    mask_bnd = +1  ->  active (solver evolves border ice)
+    ! Border mask per edge (applied AFTER yelmo_init; each in {-1,0,1}):
+    !    -1  ->  forced zero ice
+    !     0  ->  imposed = H_ice_ref (held at initial H_ice)
+    !    +1  ->  active (solver evolves border ice)
+    ! Default config: upslope (west) imposed inflow, downslope (east)
+    ! forced-zero terminus, north/south free. With zb_slope < 0, ice
+    ! flows west -> east.
     ! ============================================================
-    mask_bnd        = 1
+    mask_bnd_w      = 0                 ! west  (x = -lx/2, upslope)
+    mask_bnd_e      = -1                ! east  (x = +lx/2, downslope)
+    mask_bnd_s      = 1                 ! south (y = -ly/2)
+    mask_bnd_n      = 1                 ! north (y = +ly/2)
 
 /
 
@@ -148,7 +153,7 @@
 /
 
 &ydyn
-    solver              = "sia"
+    solver              = "diva"
     uz_method           = 3
     visc_method         = 1
     visc_const          = 1e7
@@ -171,7 +176,7 @@
     ssa_lat_bc          = "all"
     ssa_beta_max        = 1e20
     ssa_vel_max         = 5000.0
-    ssa_iter_max        = 2
+    ssa_iter_max        = 20
     ssa_iter_rel        = 0.7
     ssa_iter_conv       = 1e-2
     taud_lim            = 2e5

--- a/par/yelmo_MASK_ICE.nml
+++ b/par/yelmo_MASK_ICE.nml
@@ -1,0 +1,292 @@
+&ctrl
+
+    domain          = "MASK_ICE"        ! Synthetic mask_ice stability test
+
+    ! Timing parameters
+    time_init       = 0.0               ! [yr] Starting time
+    time_end        = 200.0             ! [yr] Ending time
+    dtt             = 1.0               ! [yr] Main loop timestep
+    dt1D_out        = 10.0              ! [yr] Frequency of 1D output
+    dt2D_out        = 20.0              ! [yr] Frequency of 2D output
+
+    ! Grid (centered on origin: x in [-lx/2, lx/2], y in [-ly/2, ly/2])
+    dx              = 2.0               ! [km] Grid resolution
+    lx              = 50.0              ! [km] Domain length, x-direction
+    ly              = 50.0              ! [km] Domain length, y-direction
+
+    ! Bedrock construction
+    !   z_bed(i,j) = zb_mean + zb_slope*x[km]
+    !              + zb_amp_sin * sin(2*pi*x/zb_wave_x) * cos(2*pi*y/zb_wave_y)
+    !              + zb_amp_noise * rand([-1,+1])
+    zb_mean         = 300.0             ! [m]   Mean bedrock elevation
+    zb_slope        = -5.0              ! [m/km] Linear slope in x
+    zb_amp_sin      = 100.0             ! [m]   Sinusoidal bump amplitude
+    zb_wave_x       = 25.0              ! [km]  Wavelength in x
+    zb_wave_y       = 25.0              ! [km]  Wavelength in y
+    zb_amp_noise    = 5.0               ! [m]   Uniform random noise amplitude (set 0 to disable)
+
+    ! Initial ice thickness
+    H_ice_init      = 500.0             ! [m]   Slab thickness everywhere
+    H_ice_noise     = 5.0               ! [m]   Uniform random noise amplitude on H_ice (set 0 to disable)
+
+    ! Boundary forcing
+    z_sl_const      = -5000.0           ! [m]   Sea level (very low, no floating ice expected)
+    T_srf_const     = -20.0             ! [degC] Surface temperature anomaly relative to T0
+    smb_const       = 0.3               ! [m/yr] Surface mass balance
+    Q_geo_const     = 50.0              ! [mW/m2] Geothermal heat flux
+
+    ! ============================================================
+    ! Border mask (applied uniformly to all four border rings AFTER
+    ! yelmo_init):
+    !    mask_bnd = -1  ->  forced zero ice (ablation)
+    !    mask_bnd =  0  ->  imposed = H_ice_ref (held at initial H_ice)
+    !    mask_bnd = +1  ->  active (solver evolves border ice)
+    ! ============================================================
+    mask_bnd        = 1
+
+/
+
+&yelmo
+    domain          = "MASK_ICE"
+    grid_name       = "MASK_ICE"
+    grid_path       = "none"
+    phys_const      = "Earth"
+    experiment      = "MASK_ICE"        ! Routes to boundaries="mask"
+    nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
+    nml_ydyn        = "ydyn"
+    nml_ytill       = "ytill"
+    nml_yneff       = "yneff"
+    nml_ymat        = "ymat"
+    nml_ytherm      = "ytherm"
+    nml_masks       = "yelmo_masks"
+    nml_init_topo   = "yelmo_init_topo"
+    nml_data        = "yelmo_data"
+    restart         = "no"
+    restart_z_bed   = False
+    restart_H_ice   = False
+    restart_relax   = 1e3
+    log_timestep    = False
+    disable_kill    = True              ! Keep the test running even if PC tolerance is exceeded
+    zeta_scale      = "exp"
+    zeta_exp        = 2.0
+    nz_aa           = 10
+    dt_method       = 2                 ! adaptive, predictor-corrector
+    dt_min          = 0.01
+    cfl_max         = 0.1
+    cfl_diff_max    = 0.12
+    pc_method       = "AB-SAM"
+    pc_controller   = "PI42"
+    pc_use_H_pred   = False
+    pc_filter_vel   = False
+    pc_corr_vel     = False
+    pc_n_redo       = 5
+    pc_tol          = 50.0
+    pc_eps          = 10.0
+/
+
+&ytopo
+    solver              = "impl-lis"
+    surf_gl_method      = 0
+    grad_lim            = 0.5
+    grad_lim_zb         = 0.5
+    dHdt_dyn_lim        = 100.0
+    margin2nd           = False
+    margin_flt_subgrid  = False
+    use_bmb             = False
+    topo_fixed          = False
+    topo_rel            = 0
+    topo_rel_tau        = 10.0
+    topo_rel_field      = "H_ref"
+
+    bmb_gl_method       = "pmp"
+    gl_sep              = 1
+    gz_nx               = 15
+
+    dist_grz            = 200.0
+    gz_Hg0              = 0.0
+    gz_Hg1              = 0.0
+
+    dmb_method          = 0
+    dmb_alpha_max       = 60.0
+    dmb_tau             = 100.0
+    dmb_sigma_ref       = 300.0
+    dmb_m_d             = 3.0
+    dmb_m_r             = 1.0
+
+    fmb_method          = 0
+    fmb_scale           = 1.0
+/
+
+&ycalv
+    use_lsf             = False
+    dt_lsf              = -1
+    calv_flt_method     = "zero"
+    calv_grnd_method    = "zero"
+
+    H_min_grnd          = 0.0
+    H_min_flt           = 0.0
+    sd_min              = 100.0
+    sd_max              = 500.0
+    calv_grnd_max       = 0.0
+
+    calv_tau            = 1.0
+    calv_thin           = 30.0
+    k2                  = 3.2e9
+    w2                  = 0.0
+    kt_ref              = 0.0025
+    kt_deep             = 0.1
+    tau_ice             = 250.0e3
+
+    Hc_ref_flt          = 200.0
+    Hc_ref_grnd         = 200.0
+    Hc_ref_thin         = 50.0
+    Hc_deep             = 500.0
+    zb_deep_0           = -1000.0
+    zb_deep_1           = -1500.0
+    zb_sigma            = 0.0
+/
+
+&ydyn
+    solver              = "sia"
+    uz_method           = 3
+    visc_method         = 1
+    visc_const          = 1e7
+    beta_method         = 3
+    beta_const          = 1e3
+    beta_q              = 0.2
+    beta_u0             = 100.0
+    beta_gl_scale       = 0
+    beta_gl_stag        = 1
+    beta_gl_f           = 1.0
+    taud_gl_method      = 0
+    H_grnd_lim          = 500.0
+    beta_min            = 0.0
+    eps_0               = 1e-6
+    scale_T             = 1
+    T_frz               = -3.0
+    ssa_solver              = "energy"
+    ssa_lis_opt_residual    = "-i bicgsafe -p jacobi -maxiter 100 -tol 1.0e-4 -initx_zeros false"
+    ssa_lis_opt_energy      = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"
+    ssa_lat_bc          = "all"
+    ssa_beta_max        = 1e20
+    ssa_vel_max         = 5000.0
+    ssa_iter_max        = 2
+    ssa_iter_rel        = 0.7
+    ssa_iter_conv       = 1e-2
+    taud_lim            = 2e5
+    cb_sia              = 0.0
+/
+
+&ytill
+    method          = 1
+    scale_zb        = 0
+    scale_sed       = 0
+    is_angle        = True
+    n_sd            = 1
+    f_sed           = 1.0
+    sed_min         = 5.0
+    sed_max         = 15.0
+    z0              = -300.0
+    z1              =  200.0
+    cf_min          =  0.1
+    cf_ref          =  30.0
+/
+
+&yneff
+    method          = 3
+    nxi             = 0
+    const           = 1e7
+    p               = 0.0
+    H_w_max         = -1.0
+    N0              = 1000.0
+    delta           = 0.02
+    e0              = 0.69
+    Cc              = 0.12
+    s_const         = 0.5
+/
+
+&ymat
+    flow_law                = "glen"
+    rf_method               = 1
+    rf_const                = 1e-16
+    rf_use_eismint2         = False
+    rf_with_water           = False
+    n_glen                  = 3.0
+    visc_min                = 1e3
+    de_max                  = 2.0
+    enh_method              = "shear3D"
+    enh_shear               = 1.0
+    enh_stream              = 1.0
+    enh_shlf                = 1.0
+    enh_umin                = 50.0
+    enh_umax                = 500.0
+    calc_age                = False
+    age_iso                 = 0.0
+    tracer_method           = "expl"
+    tracer_impl_kappa       = 1.5
+/
+
+&ytherm
+    method          = "temp"
+    qb_method       = 2
+    dt_method       = "FE"
+    solver_advec    = "impl-upwind"
+    gamma           = 1.0
+    use_strain_sia  = False
+    use_const_cp    = True
+    const_cp        = 2009.0
+    use_const_kt    = True
+    const_kt        = 6.62e7
+    enth_cr         = 1e-3
+    omega_max       = 0.01
+    till_rate       = 0.0
+    H_w_max         = 2.0
+
+    rock_method     = "equil"
+    nzr_aa          = 5
+    zeta_scale_rock = "exp-inv"
+    zeta_exp_rock   = 2.0
+    H_rock          = 2000.0
+    cp_rock         = 1000.0
+    kt_rock         = 6.3e7
+/
+
+&yelmo_masks
+    basins_load     = False
+    basins_path     = "none"
+    basins_nms      = "basin" "basin_mask"
+    regions_load    = False
+    regions_path    = "none"
+    regions_nms     = "mask" "None"
+/
+
+&yelmo_init_topo
+    init_topo_load  = False
+    init_topo_path  = "none"
+    init_topo_names = "H_ice" "z_bed" "z_bed_sd" "z_srf"
+    init_topo_state = 0
+    z_bed_f_sd      = 0.0
+    smooth_H_ice    = 0.0
+    smooth_z_bed    = 0.0
+/
+
+&yelmo_data
+    pd_topo_load      = False
+    pd_topo_path      = "none"
+    pd_topo_names     = "H_ice" "z_bed" "z_bed_sd" "z_srf"
+    pd_tsrf_load      = False
+    pd_tsrf_path      = "none"
+    pd_tsrf_name      = "T_srf"
+    pd_tsrf_monthly   = False
+    pd_smb_load       = False
+    pd_smb_path       = "none"
+    pd_smb_name       = "smb"
+    pd_smb_monthly    = False
+    pd_vel_load       = False
+    pd_vel_path       = "none"
+    pd_vel_names      = "ux_srf" "uy_srf"
+    pd_age_load       = False
+    pd_age_path       = "none"
+    pd_age_names      = "age_iso" "depth_iso"
+/

--- a/src/physics/basal_dragging.f90
+++ b/src/physics/basal_dragging.f90
@@ -502,12 +502,12 @@ contains
                 ! in MISMIP symmetric experiments
                 beta(1,:) = beta(2,:) 
 
-            case("infinite") 
-            
+            case("infinite","mask")
+
                 beta(1,:)  = beta(nx-1,:)
-                beta(nx,:) = beta(2,:) 
+                beta(nx,:) = beta(2,:)
                 beta(:,1)  = beta(:,2)
-                beta(:,ny) = beta(:,ny-1) 
+                beta(:,ny) = beta(:,ny-1)
 
         end select
 
@@ -617,9 +617,9 @@ contains
                 beta_acy(:,ny-1) = beta_acy(:,2) 
                 beta_acy(:,ny)   = beta_acy(:,3)
 
-            case("infinite","MISMIP3D") 
+            case("infinite","MISMIP3D","mask")
 
-                beta_acx(1,:)    = beta_acx(2,:) 
+                beta_acx(1,:)    = beta_acx(2,:)
                 beta_acx(nx-1,:) = beta_acx(nx-2,:) 
                 beta_acx(nx,:)   = beta_acx(nx-2,:) 
                 beta_acx(:,1)    = beta_acx(:,2)

--- a/src/physics/mass_conservation.f90
+++ b/src/physics/mass_conservation.f90
@@ -814,11 +814,19 @@ contains
         ! (applied universally, independent of the boundary BC choice above)
         where (mask_ice .eq. 0) H_ice_new = H_ice_ref
 
-        ! Determine rate of mass balance related to changes applied here
-        ! (10% higher for safety - this will be adjusted by apply_tendency later anyway)
-        if (dt .ne. 0.0) then 
-            mb_resid = 1.1 * (H_ice_new - H_ice) / dt 
-        else 
+        ! Determine rate of mass balance related to changes applied here.
+        ! For mask_ice == 0 (imposed) cells use no overshoot, so apply_tendency
+        ! lands exactly on H_ice_ref each step (no drift from a persistent
+        ! dyn inflow/outflow imbalance). For other cells keep the 10% safety
+        ! margin so the apply_tendency clip-to-zero handles the mask_ice == -1
+        ! path robustly.
+        if (dt .ne. 0.0) then
+            where (mask_ice .eq. 0)
+                mb_resid = (H_ice_new - H_ice) / dt
+            elsewhere
+                mb_resid = 1.1_wp * (H_ice_new - H_ice) / dt
+            end where
+        else
             mb_resid = 0.0
         end if
 

--- a/src/physics/mass_conservation.f90
+++ b/src/physics/mass_conservation.f90
@@ -798,6 +798,11 @@ contains
                 H_ice_new(:,1)  = 0.0
                 H_ice_new(:,ny) = 0.0
 
+            case("mask")
+                ! Defer border treatment entirely to bnd%mask_ice.
+
+                where (mask_ice .eq. -1) H_ice_new = 0.0_wp
+
             case DEFAULT    ! e.g., None/none
                 ! Apply forced-zero mask from bnd%mask_ice
 

--- a/src/physics/solver_advection.f90
+++ b/src/physics/solver_advection.f90
@@ -197,10 +197,10 @@ contains
                 bcs(3) = "infinite"
                 bcs(4) = "periodic" 
 
-            case("infinite")
+            case("infinite","mask")
 
-                bcs(1:4) = "infinite" 
-            
+                bcs(1:4) = "infinite"
+
             case("zeros")
 
                 bcs(1:4) = "zero" 

--- a/src/physics/solver_ssa_ac.f90
+++ b/src/physics/solver_ssa_ac.f90
@@ -200,10 +200,10 @@ contains
                 bcs(3) = "free-slip"
                 bcs(4) = "periodic"
             
-            case("infinite")
+            case("infinite","mask")
 
-                bcs(1:4) = "free-slip" 
-            
+                bcs(1:4) = "free-slip"
+
             case("zeros")
 
                 bcs(1:4) = "no-slip" 

--- a/src/physics/solver_ssa_ac_energy.f90
+++ b/src/physics/solver_ssa_ac_energy.f90
@@ -107,7 +107,7 @@ contains
             case("periodic-y")
                 bcs(1) = "free-slip"; bcs(2) = "periodic"
                 bcs(3) = "free-slip"; bcs(4) = "periodic"
-            case("infinite")
+            case("infinite","mask")
                 bcs(1:4) = "free-slip"
             case("zeros")
                 bcs(1:4) = "no-slip"

--- a/src/yelmo_dynamics.f90
+++ b/src/yelmo_dynamics.f90
@@ -1540,12 +1540,18 @@ contains
 
             case("infinite")
                 ! ajr: we should check setting border H values equal to inner neighbors
-                
+
                 write(*,*) "calc_ice_thickness:: error: boundary method not implemented yet: "//trim(boundaries)
                 write(*,*) "TO DO!"
-                stop 
+                stop
 
-            case DEFAULT 
+            case("mask")
+
+                ! Border velocity values are governed by the mask_ice mask
+                ! together with the "infinite"-style neighbor stencils used
+                ! by the dynamics solvers. No explicit border assignment here.
+
+            case DEFAULT
 
                 write(*,*) "calc_ice_thickness:: error: boundary method not recognized: "//trim(boundaries)
                 stop 

--- a/src/yelmo_ice.f90
+++ b/src/yelmo_ice.f90
@@ -849,12 +849,20 @@ contains
                 dom%dyn%par%boundaries  = "periodic-x"
                 dom%thrm%par%boundaries = "periodic-x"
 
-            case("infinite") 
-                ! Set border points equal to interior neighbors 
+            case("infinite")
+                ! Set border points equal to interior neighbors
 
                 dom%tpo%par%boundaries  = "infinite"
                 dom%dyn%par%boundaries  = "infinite"
                 dom%thrm%par%boundaries = "infinite"
+
+            case("MASK_ICE")
+                ! Border treatment is driven by bnd%mask_ice; solvers use
+                ! "infinite"-style neighbor stencils.
+
+                dom%tpo%par%boundaries  = "mask"
+                dom%dyn%par%boundaries  = "mask"
+                dom%thrm%par%boundaries = "mask"
 
             case DEFAULT
                 ! zeros by default - safest option

--- a/src/yelmo_tools.f90
+++ b/src/yelmo_tools.f90
@@ -126,11 +126,11 @@ contains
 
         select case(trim(boundaries))
 
-            case("infinite")
+            case("infinite","mask")
                 im1 = max(i-1,1)
-                ip1 = min(i+1,nx) 
+                ip1 = min(i+1,nx)
                 jm1 = max(j-1,1)
-                jp1 = min(j+1,ny) 
+                jp1 = min(j+1,ny)
 
             case("MISMIP3D","TROUGH")
                 im1 = max(i-1,1)
@@ -222,6 +222,7 @@ contains
             case("TROUGH");     code = BND_TROUGH
             case("periodic");   code = BND_PERIODIC
             case("periodic-x"); code = BND_PERIODIC_X
+            case("mask");       code = BND_INFINITE
             case default
                 write(io_unit_err,*) "boundary_code:: Error: Boundary string not recognized: "//trim(boundaries)
                 stop
@@ -813,10 +814,10 @@ end if
         ! is the same, not the variable itself.
         select case(trim(boundaries))
 
-            case("infinite","MISMIP3D","TROUGH") 
+            case("infinite","MISMIP3D","TROUGH","mask")
                 dvardx(1,:)  = dvardx(2,:)
                 dvardx(nx,:) = dvardx(nx-1,:)
-            
+
         end select
 
         ! Finally, ensure that gradient is beneath desired limit 
@@ -919,7 +920,7 @@ end if
         ! is the same, not the variable itself.
         select case(trim(boundaries))
 
-            case("infinite") 
+            case("infinite","mask")
                 dvardy(:,1)  = dvardy(:,2)
                 dvardy(:,ny) = dvardy(:,ny-1)
 
@@ -1220,17 +1221,17 @@ end if
                 var(1,:)    = var(2,:)          ! x=0, Symmetry 
                 var(nx,:)   = 0.0               ! x=800km, no ice
                 
-            case("infinite")
-                ! Set border points equal to inner neighbors 
+            case("infinite","mask")
+                ! Set border points equal to inner neighbors
 
                 call fill_borders_2D(var,nfill=1)
 
-            case("fixed") 
+            case("fixed")
                 ! Set border points equal to prescribed values from array
 
                 call fill_borders_2D(var,nfill=1,fill=var_ref)
 
-            case DEFAULT 
+            case DEFAULT
 
                 write(io_unit_err,*) "set_boundaries_2D_aa:: error: boundary method not recognized."
                 write(io_unit_err,*) "boundaries = ", trim(boundaries)
@@ -1307,18 +1308,18 @@ end if
                 var_acx(:,1)    = var_acx(:,2)
                 var_acx(:,ny)   = var_acx(:,ny-1) 
 
-            case("infinite") 
-                
-                var_acx(1,:)    = var_acx(2,:) 
-                var_acx(nx-1,:) = var_acx(nx-2,:) 
-                var_acx(nx,:)   = var_acx(nx-1,:) 
-                var_acx(:,1)    = var_acx(:,2)
-                var_acx(:,ny)   = var_acx(:,ny-1) 
+            case("infinite","mask")
 
-            case("MISMIP3D","TROUGH") 
-                
-                !var_acx(1,:)    = var_acx(2,:) 
-                var_acx(nx-1,:) = var_acx(nx-2,:) 
+                var_acx(1,:)    = var_acx(2,:)
+                var_acx(nx-1,:) = var_acx(nx-2,:)
+                var_acx(nx,:)   = var_acx(nx-1,:)
+                var_acx(:,1)    = var_acx(:,2)
+                var_acx(:,ny)   = var_acx(:,ny-1)
+
+            case("MISMIP3D","TROUGH")
+
+                !var_acx(1,:)    = var_acx(2,:)
+                var_acx(nx-1,:) = var_acx(nx-2,:)
                 var_acx(nx,:)   = var_acx(nx-1,:) 
                 var_acx(:,1)    = var_acx(:,2)
                 var_acx(:,ny)   = var_acx(:,ny-1) 
@@ -1360,13 +1361,13 @@ end if
                 var_acx(:,1,:)    = var_acx(:,2,:)
                 var_acx(:,ny,:)   = var_acx(:,ny-1,:) 
 
-            case("infinite") 
-                
-                var_acx(1,:,:)    = var_acx(2,:,:) 
-                var_acx(nx-1,:,:) = var_acx(nx-2,:,:) 
-                var_acx(nx,:,:)   = var_acx(nx-1,:,:) 
+            case("infinite","mask")
+
+                var_acx(1,:,:)    = var_acx(2,:,:)
+                var_acx(nx-1,:,:) = var_acx(nx-2,:,:)
+                var_acx(nx,:,:)   = var_acx(nx-1,:,:)
                 var_acx(:,1,:)    = var_acx(:,2,:)
-                var_acx(:,ny,:)   = var_acx(:,ny-1,:) 
+                var_acx(:,ny,:)   = var_acx(:,ny-1,:)
 
             case("MISMIP3D","TROUGH") 
                 
@@ -1413,25 +1414,25 @@ end if
                 var_acy(:,ny-1) = var_acy(:,ny-2) 
                 var_acy(:,ny)   = var_acy(:,ny-1)
 
-            case("infinite") 
-                
-                var_acy(1,:)    = var_acy(2,:) 
-                var_acy(nx,:)   = var_acy(nx-1,:) 
+            case("infinite","mask")
+
+                var_acy(1,:)    = var_acy(2,:)
+                var_acy(nx,:)   = var_acy(nx-1,:)
                 var_acy(:,1)    = var_acy(:,2)
-                var_acy(:,ny-1) = var_acy(:,ny-2) 
+                var_acy(:,ny-1) = var_acy(:,ny-2)
                 var_acy(:,ny)   = var_acy(:,ny-1)
 
-            case("MISMIP3D","TROUGH") 
-                
-                var_acy(1,:)    = var_acy(2,:) 
-                var_acy(nx,:)   = var_acy(nx-1,:) 
+            case("MISMIP3D","TROUGH")
+
+                var_acy(1,:)    = var_acy(2,:)
+                var_acy(nx,:)   = var_acy(nx-1,:)
                 var_acy(:,1)    = var_acy(:,2)
-                var_acy(:,ny-1) = var_acy(:,ny-2) 
+                var_acy(:,ny-1) = var_acy(:,ny-2)
                 var_acy(:,ny)   = var_acy(:,ny-1)
 
-        end select 
+        end select
 
-        return 
+        return
 
     end subroutine set_boundaries_2D_acy
 
@@ -1466,15 +1467,15 @@ end if
                 var_acy(:,ny-1,:) = var_acy(:,ny-2,:) 
                 var_acy(:,ny,:)   = var_acy(:,ny-1,:)
 
-            case("infinite") 
-                
-                var_acy(1,:,:)    = var_acy(2,:,:) 
-                var_acy(nx,:,:)   = var_acy(nx-1,:,:) 
+            case("infinite","mask")
+
+                var_acy(1,:,:)    = var_acy(2,:,:)
+                var_acy(nx,:,:)   = var_acy(nx-1,:,:)
                 var_acy(:,1,:)    = var_acy(:,2,:)
-                var_acy(:,ny-1,:) = var_acy(:,ny-2,:) 
+                var_acy(:,ny-1,:) = var_acy(:,ny-2,:)
                 var_acy(:,ny,:)   = var_acy(:,ny-1,:)
 
-            case("MISMIP3D","TROUGH") 
+            case("MISMIP3D","TROUGH")
                 
                 var_acy(1,:,:)    = var_acy(2,:,:) 
                 var_acy(nx,:,:)   = var_acy(nx-1,:,:) 

--- a/tests/yelmo_mask_ice.f90
+++ b/tests/yelmo_mask_ice.f90
@@ -1,0 +1,300 @@
+program yelmo_mask_ice
+    ! Synthetic stability test for bnd%mask_ice border treatment.
+    ! Sets up a small box domain with sinusoidal + noisy bedrock and
+    ! a slab of ice with noise, then forces all four border rings to a
+    ! single mask_ice value (mask_bnd = -1, 0, or +1) read from the
+    ! namelist, after yelmo_init has run. Drives the model forward
+    ! and writes 2D/1D output for inspection.
+
+    use nml
+    use ncio
+    use yelmo
+    use timestepping
+
+    implicit none
+
+    type(tstep_class) :: ts
+    type(yelmo_class) :: yelmo1
+
+    character(len=56)  :: domain, grid_name
+    character(len=256) :: outfldr, file2D, file1D, file_restart
+    character(len=512) :: path_par
+
+    ! Timing
+    real(wp) :: time_init, time_end, dtt, dt1D_out, dt2D_out
+
+    ! Geometry
+    real(wp) :: lx, ly, dx
+    integer  :: nx, ny
+
+    ! Bedrock construction
+    real(wp) :: zb_mean
+    real(wp) :: zb_slope
+    real(wp) :: zb_amp_sin
+    real(wp) :: zb_wave_x, zb_wave_y
+    real(wp) :: zb_amp_noise
+
+    ! Ice and boundary forcing
+    real(wp) :: H_ice_init
+    real(wp) :: H_ice_noise
+    real(wp) :: z_sl_const
+    real(wp) :: T_srf_const
+    real(wp) :: smb_const
+    real(wp) :: Q_geo_const
+
+    ! Mask choice on all four borders
+    integer  :: mask_bnd
+
+    ! Local
+    integer  :: i, j
+    real(wp), allocatable :: rnd(:,:)
+    real(8)  :: cpu_start_time, cpu_end_time, cpu_dtime
+    real(wp) :: two_pi
+
+    two_pi = 2.0_wp * pi
+
+    call yelmo_cpu_time(cpu_start_time)
+
+    outfldr = "./"
+    call yelmo_load_command_line_args(path_par)
+
+    file2D       = trim(outfldr)//"yelmo2D.nc"
+    file1D       = trim(outfldr)//"yelmo1D.nc"
+    file_restart = trim(outfldr)//"yelmo_restart.nc"
+
+    ! === Load control parameters ===
+    call nml_read(path_par,"ctrl","domain",       domain)
+
+    call nml_read(path_par,"ctrl","time_init",    time_init)
+    call nml_read(path_par,"ctrl","time_end",     time_end)
+    call nml_read(path_par,"ctrl","dtt",          dtt)
+    call nml_read(path_par,"ctrl","dt1D_out",     dt1D_out)
+    call nml_read(path_par,"ctrl","dt2D_out",     dt2D_out)
+
+    call nml_read(path_par,"ctrl","dx",           dx)
+    call nml_read(path_par,"ctrl","lx",           lx)
+    call nml_read(path_par,"ctrl","ly",           ly)
+
+    call nml_read(path_par,"ctrl","zb_mean",      zb_mean)
+    call nml_read(path_par,"ctrl","zb_slope",     zb_slope)
+    call nml_read(path_par,"ctrl","zb_amp_sin",   zb_amp_sin)
+    call nml_read(path_par,"ctrl","zb_wave_x",    zb_wave_x)
+    call nml_read(path_par,"ctrl","zb_wave_y",    zb_wave_y)
+    call nml_read(path_par,"ctrl","zb_amp_noise", zb_amp_noise)
+
+    call nml_read(path_par,"ctrl","H_ice_init",   H_ice_init)
+    call nml_read(path_par,"ctrl","H_ice_noise",  H_ice_noise)
+    call nml_read(path_par,"ctrl","z_sl_const",   z_sl_const)
+    call nml_read(path_par,"ctrl","T_srf_const",  T_srf_const)
+    call nml_read(path_par,"ctrl","smb_const",    smb_const)
+    call nml_read(path_par,"ctrl","Q_geo_const",  Q_geo_const)
+
+    call nml_read(path_par,"ctrl","mask_bnd",     mask_bnd)
+
+    if (mask_bnd .lt. -1 .or. mask_bnd .gt. 1) then
+        write(*,*) "yelmo_mask_ice:: Error: mask_bnd must be -1, 0, or 1. Got: ", mask_bnd
+        stop
+    end if
+
+    ! === Grid ===
+    grid_name = "MASK_ICE"
+    nx = int(lx/dx) + 1
+    ny = int(ly/dx) + 1
+
+    call yelmo_init_grid(yelmo1%grd,grid_name,units="km", &
+                            x0=-0.5_wp*lx,dx=dx,nx=nx, &
+                            y0=-0.5_wp*ly,dy=dx,ny=ny)
+
+    ! === Initialize ice sheet model (no topo loading) ===
+    call yelmo_init(yelmo1,filename=path_par,grid_def="none",time=time_init, &
+                        load_topo=.FALSE.,domain=domain,grid_name=grid_name)
+
+    nx = yelmo1%grd%nx
+    ny = yelmo1%grd%ny
+
+    ! === Define bedrock topography ===
+    ! z_bed = zb_mean + slope*x + amp_sin * sin(2*pi*x/Lx_wave) * cos(2*pi*y/Ly_wave)
+    !               + amp_noise * rand([-1,+1])
+
+    allocate(rnd(nx,ny))
+    call random_seed_init()
+    call random_number(rnd)
+    rnd = 2.0_wp*rnd - 1.0_wp     ! map [0,1] -> [-1,+1]
+
+    do j = 1, ny
+    do i = 1, nx
+        yelmo1%bnd%z_bed(i,j) = zb_mean &
+            + zb_slope * (yelmo1%grd%x(i,j)*1e-3_wp) &
+            + zb_amp_sin * sin(two_pi*yelmo1%grd%x(i,j)*1e-3_wp/zb_wave_x) &
+                         * cos(two_pi*yelmo1%grd%y(i,j)*1e-3_wp/zb_wave_y) &
+            + zb_amp_noise * rnd(i,j)
+    end do
+    end do
+
+    ! === Define initial ice thickness ===
+    ! H_ice = H_ice_init + H_ice_noise * rand([-1,+1])
+    call random_number(rnd)
+    rnd = 2.0_wp*rnd - 1.0_wp
+    yelmo1%tpo%now%H_ice = max(0.0_wp, H_ice_init + H_ice_noise*rnd)
+
+    ! Surface elevation
+    yelmo1%tpo%now%z_srf = yelmo1%bnd%z_bed + yelmo1%tpo%now%H_ice
+
+    ! Reference ice thickness (used when mask_ice == 0)
+    yelmo1%bnd%H_ice_ref = yelmo1%tpo%now%H_ice
+
+    ! === Boundary fields ===
+    yelmo1%bnd%z_sl     = z_sl_const
+    yelmo1%bnd%bmb_shlf = 0.0_wp
+    yelmo1%bnd%T_shlf   = yelmo1%bnd%c%T0
+    yelmo1%bnd%H_sed    = 0.0_wp
+    yelmo1%bnd%T_srf    = yelmo1%bnd%c%T0 + T_srf_const
+    yelmo1%bnd%smb      = smb_const
+    yelmo1%bnd%Q_geo    = Q_geo_const
+
+    ! === Set mask_ice on the four border rings ===
+    ! Interior is left as initialized by ybound_define_mask_ice (= 1 for
+    ! the MASK_ICE experiment, which routes through the DEFAULT case).
+    yelmo1%bnd%mask_ice(1,:)  = mask_bnd
+    yelmo1%bnd%mask_ice(nx,:) = mask_bnd
+    yelmo1%bnd%mask_ice(:,1)  = mask_bnd
+    yelmo1%bnd%mask_ice(:,ny) = mask_bnd
+
+    write(*,*) "yelmo_mask_ice:: domain    = ", trim(domain)
+    write(*,*) "yelmo_mask_ice:: nx, ny    = ", nx, ny
+    write(*,*) "yelmo_mask_ice:: dx [km]   = ", dx
+    write(*,*) "yelmo_mask_ice:: mask_bnd  = ", mask_bnd
+    write(*,*) "yelmo_mask_ice:: H_ice min/max = ", minval(yelmo1%tpo%now%H_ice), maxval(yelmo1%tpo%now%H_ice)
+    write(*,*) "yelmo_mask_ice:: z_bed min/max = ", minval(yelmo1%bnd%z_bed),     maxval(yelmo1%bnd%z_bed)
+
+    call yelmo_print_bound(yelmo1%bnd)
+
+    ! === Initialize state (dyn, therm, mat) ===
+    call yelmo_init_state(yelmo1,time=time_init,thrm_method="robin")
+
+    ! === Initialize timestepping ===
+    call tstep_init(ts,time_init,time_end,method="const",units="year", &
+                                            time_ref=0.0_wp,const_rel=0.0_wp,const_cal=0.0_wp)
+
+    ! === Write initial state ===
+    call yelmo_write_init(yelmo1,file2D,time_init=ts%time,units="years")
+    call write_step_2D(yelmo1,file2D,time=ts%time)
+
+    call yelmo_write_reg_init(yelmo1,file1D,time_init=ts%time,units="years", &
+                              mask=(yelmo1%bnd%mask_ice /= -1))
+    call yelmo_write_reg_step(yelmo1,file1D,time=ts%time)
+
+    ! === Advance timesteps ===
+    do while (.not. ts%is_finished)
+
+        call tstep_update(ts,dtt,verbose=.FALSE.)
+
+        call yelmo_update(yelmo1,ts%time)
+
+        if (mod(nint(ts%time_elapsed*100),nint(dt2D_out*100))==0) then
+            call write_step_2D(yelmo1,file2D,time=ts%time)
+        end if
+
+        if (mod(nint(ts%time_elapsed*100),nint(dt1D_out*100))==0) then
+            call yelmo_write_reg_step(yelmo1,file1D,time=ts%time)
+        end if
+
+        if (mod(ts%time,100.0)==0 .and. (.not. yelmo_log)) then
+            write(*,"(a,f14.4,a,2g14.4)") "yelmo:: time = ", ts%time, &
+                "  H_ice min/max = ", minval(yelmo1%tpo%now%H_ice), maxval(yelmo1%tpo%now%H_ice)
+        end if
+
+    end do
+
+    ! === Summary ===
+    write(*,*) "====== "//trim(domain)//"  mask_bnd = ",mask_bnd," ======="
+    write(*,*) "H_ice min/max = ", minval(yelmo1%tpo%now%H_ice), maxval(yelmo1%tpo%now%H_ice)
+
+    call yelmo_restart_write(yelmo1,file_restart,time=ts%time)
+    call yelmo_end(yelmo1,time=ts%time)
+
+    call yelmo_cpu_time(cpu_end_time,cpu_start_time,cpu_dtime)
+    write(*,"(a,f12.3,a)") "Time  = ",cpu_dtime/60.0 ," min"
+    write(*,"(a,f12.1,a)") "Speed = ",(1e-3*(ts%time_end-ts%time_init))/(cpu_dtime/3600.0), " kiloyears / hr"
+
+contains
+
+    subroutine random_seed_init()
+        ! Deterministic seed so the noise field is reproducible across runs.
+        integer :: n
+        integer, allocatable :: seed(:)
+        call random_seed(size=n)
+        allocate(seed(n))
+        seed = 20260513
+        call random_seed(put=seed)
+    end subroutine random_seed_init
+
+    subroutine write_step_2D(ylmo,filename,time)
+
+        implicit none
+
+        type(yelmo_class), intent(IN) :: ylmo
+        character(len=*),  intent(IN) :: filename
+        real(wp),          intent(IN) :: time
+
+        integer :: ncid, n
+
+        call nc_open(filename,ncid,writable=.TRUE.)
+        n = nc_time_index(filename,"time",time,ncid)
+        call nc_write(filename,"time",time,dim1="time",start=[n],count=[1],ncid=ncid)
+
+        call yelmo_write_step_model_metrics(filename,ylmo,n,ncid)
+
+        ! Topography
+        call nc_write(filename,"H_ice",ylmo%tpo%now%H_ice,units="m",long_name="Ice thickness", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"z_srf",ylmo%tpo%now%z_srf,units="m",long_name="Surface elevation", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"z_bed",ylmo%bnd%z_bed,units="m",long_name="Bedrock elevation", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"H_grnd",ylmo%tpo%now%H_grnd,units="m",long_name="Grounded ice thickness", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"f_grnd",ylmo%tpo%now%f_grnd,units="1",long_name="Grounded fraction", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"f_ice",ylmo%tpo%now%f_ice,units="1",long_name="Ice-covered fraction", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"mask_bed",ylmo%tpo%now%mask_bed,units="",long_name="Bed mask", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+
+        ! Mass balance components
+        call nc_write(filename,"mb_net",ylmo%tpo%now%mb_net,units="m/yr",long_name="Net mass balance", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"mb_resid",ylmo%tpo%now%mb_resid,units="m/yr",long_name="Residual mass balance", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"mb_relax",ylmo%tpo%now%mb_relax,units="m/yr",long_name="Relaxation mass balance", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"dHidt",ylmo%tpo%now%dHidt,units="m/yr",long_name="dH_ice/dt", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"tau_relax",ylmo%tpo%now%tau_relax,units="yr",long_name="Relaxation timescale", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+
+        ! Boundary fields
+        call nc_write(filename,"mask_ice",ylmo%bnd%mask_ice,units="",long_name="Boundary ice mask (-1,0,1)", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"H_ice_ref",ylmo%bnd%H_ice_ref,units="m",long_name="Reference ice thickness", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"smb",ylmo%tpo%now%smb,units="m/yr",long_name="Surface mass balance", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"T_srf",ylmo%bnd%T_srf,units="K",long_name="Surface temperature", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+
+        ! Dynamics
+        call nc_write(filename,"uxy_bar",ylmo%dyn%now%uxy_bar,units="m/yr",long_name="Vertically averaged velocity magnitude", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"uxy_b",ylmo%dyn%now%uxy_b,units="m/yr",long_name="Basal sliding velocity magnitude", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+        call nc_write(filename,"taud",ylmo%dyn%now%taud,units="Pa",long_name="Driving stress magnitude", &
+                      dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+
+        call nc_close(ncid)
+
+        return
+
+    end subroutine write_step_2D
+
+end program yelmo_mask_ice

--- a/tests/yelmo_mask_ice.f90
+++ b/tests/yelmo_mask_ice.f90
@@ -42,8 +42,8 @@ program yelmo_mask_ice
     real(wp) :: smb_const
     real(wp) :: Q_geo_const
 
-    ! Mask choice on all four borders
-    integer  :: mask_bnd
+    ! Mask choice per border ring (west/east/south/north)
+    integer  :: mask_bnd_w, mask_bnd_e, mask_bnd_s, mask_bnd_n
 
     ! Local
     integer  :: i, j
@@ -89,12 +89,15 @@ program yelmo_mask_ice
     call nml_read(path_par,"ctrl","smb_const",    smb_const)
     call nml_read(path_par,"ctrl","Q_geo_const",  Q_geo_const)
 
-    call nml_read(path_par,"ctrl","mask_bnd",     mask_bnd)
+    call nml_read(path_par,"ctrl","mask_bnd_w",   mask_bnd_w)
+    call nml_read(path_par,"ctrl","mask_bnd_e",   mask_bnd_e)
+    call nml_read(path_par,"ctrl","mask_bnd_s",   mask_bnd_s)
+    call nml_read(path_par,"ctrl","mask_bnd_n",   mask_bnd_n)
 
-    if (mask_bnd .lt. -1 .or. mask_bnd .gt. 1) then
-        write(*,*) "yelmo_mask_ice:: Error: mask_bnd must be -1, 0, or 1. Got: ", mask_bnd
-        stop
-    end if
+    call check_mask_bnd(mask_bnd_w,"mask_bnd_w")
+    call check_mask_bnd(mask_bnd_e,"mask_bnd_e")
+    call check_mask_bnd(mask_bnd_s,"mask_bnd_s")
+    call check_mask_bnd(mask_bnd_n,"mask_bnd_n")
 
     ! === Grid ===
     grid_name = "MASK_ICE"
@@ -155,15 +158,16 @@ program yelmo_mask_ice
     ! === Set mask_ice on the four border rings ===
     ! Interior is left as initialized by ybound_define_mask_ice (= 1 for
     ! the MASK_ICE experiment, which routes through the DEFAULT case).
-    yelmo1%bnd%mask_ice(1,:)  = mask_bnd
-    yelmo1%bnd%mask_ice(nx,:) = mask_bnd
-    yelmo1%bnd%mask_ice(:,1)  = mask_bnd
-    yelmo1%bnd%mask_ice(:,ny) = mask_bnd
+    yelmo1%bnd%mask_ice(1,:)  = mask_bnd_w      ! west  (x = -lx/2)
+    yelmo1%bnd%mask_ice(nx,:) = mask_bnd_e      ! east  (x = +lx/2)
+    yelmo1%bnd%mask_ice(:,1)  = mask_bnd_s      ! south (y = -ly/2)
+    yelmo1%bnd%mask_ice(:,ny) = mask_bnd_n      ! north (y = +ly/2)
 
     write(*,*) "yelmo_mask_ice:: domain    = ", trim(domain)
     write(*,*) "yelmo_mask_ice:: nx, ny    = ", nx, ny
     write(*,*) "yelmo_mask_ice:: dx [km]   = ", dx
-    write(*,*) "yelmo_mask_ice:: mask_bnd  = ", mask_bnd
+    write(*,"(a,4i4)") " yelmo_mask_ice:: mask_bnd w/e/s/n = ", &
+        mask_bnd_w, mask_bnd_e, mask_bnd_s, mask_bnd_n
     write(*,*) "yelmo_mask_ice:: H_ice min/max = ", minval(yelmo1%tpo%now%H_ice), maxval(yelmo1%tpo%now%H_ice)
     write(*,*) "yelmo_mask_ice:: z_bed min/max = ", minval(yelmo1%bnd%z_bed),     maxval(yelmo1%bnd%z_bed)
 
@@ -207,7 +211,8 @@ program yelmo_mask_ice
     end do
 
     ! === Summary ===
-    write(*,*) "====== "//trim(domain)//"  mask_bnd = ",mask_bnd," ======="
+    write(*,"(a,a,4i4,a)") " ====== "//trim(domain)//"  mask_bnd w/e/s/n = ", "", &
+        mask_bnd_w, mask_bnd_e, mask_bnd_s, mask_bnd_n, "  ======="
     write(*,*) "H_ice min/max = ", minval(yelmo1%tpo%now%H_ice), maxval(yelmo1%tpo%now%H_ice)
 
     call yelmo_restart_write(yelmo1,file_restart,time=ts%time)
@@ -218,6 +223,15 @@ program yelmo_mask_ice
     write(*,"(a,f12.1,a)") "Speed = ",(1e-3*(ts%time_end-ts%time_init))/(cpu_dtime/3600.0), " kiloyears / hr"
 
 contains
+
+    subroutine check_mask_bnd(val,name)
+        integer,          intent(IN) :: val
+        character(len=*), intent(IN) :: name
+        if (val .lt. -1 .or. val .gt. 1) then
+            write(*,*) "yelmo_mask_ice:: Error: "//trim(name)//" must be -1, 0, or 1. Got: ", val
+            stop
+        end if
+    end subroutine check_mask_bnd
 
     subroutine random_seed_init()
         ! Deterministic seed so the noise field is reproducible across runs.


### PR DESCRIPTION
## Summary

- **New `boundaries="mask"` mode** (8401a1a6) — previously the `case DEFAULT` branch in `calc_G_boundaries` (intended for the mask_ice-driven path) was unreachable, because `boundary_code` rejects unknown strings and every accepted value matched an explicit branch. `"mask"` is now a recognized value that uses `BND_INFINITE`-style neighbor stencils and delegates border `H_ice` to `bnd%mask_ice` (−1 force-zero, 0 imposed, 1 active). `experiment="MASK_ICE"` in `yelmo_init` routes to it.
- **New `tests/yelmo_mask_ice.f90` + `par/yelmo_MASK_ICE.nml`** (23112181, 16f2bf11) — small box domain (50×50 km, dx=2 km) with sloped + sinusoidal + noisy bedrock and a 500 m slab with noise. Per-edge namelist controls (`mask_bnd_w/e/s/n`) set `bnd%mask_ice` on the four border rings AFTER `yelmo_init`. Default config: upslope-imposed (w=0) / downslope-zero (e=−1) / free top-bottom (s=n=1). Built with `make mask_ice`. Solver: DIVA.
- **Bugfix: `mb_resid` overshoot at mask_ice==0** (24e7aeb6) — the `1.1×` "safety" factor in `calc_G_boundaries` left mask=0 cells biased by `−0.1·δ` below `H_ice_ref` each step, where `δ` is the pre-resid offset. With persistent dyn inflow from a thickening interior, `δ` grew and the bias compounded, leaking ~0.03 m/yr. Now `mb_resid = (H_ref − H)/dt` exactly for mask=0 cells, so `apply_tendency` lands on `H_ice_ref` every step. Other cells keep the 1.1× factor where the clip-to-zero is the real safety net.

## Test plan

- [x] `make mask_ice` builds cleanly
- [x] All four configs run to t=200 yr without kill (upslope_imposed, uniform −1 / 0 / +1)
- [x] After fix: mask=0 borders sit at `H_ice_ref` to machine precision, `dHidt = 0` exactly
- [x] mb_net accounting consistent: `mb_net = smb + mb_resid` at mask=0 cells
- [ ] Verify mask=−1 directional flow artifact resolves with DIVA (left as next investigation; out of scope for this PR)