### PR TITLE
Improved pc_eta calculation

### DIFF
--- a/par/yelmo_initmip.nml
+++ b/par/yelmo_initmip.nml
@@ -9,7 +9,7 @@
     with_ice_sheet  = True              ! Active ice-sheet component? 
     equil_method    = "opt"             ! "none", "relax", "opt"
 
-    clim_nm         = "clim_pd_grl"     ! "clim_pd_grl", "clim_pd_ant" or "clim_lgm"
+    set_nm          = "set_grl_pd"     ! "set_grl_pd", "set_ant_pd" or "set_ant_lgm"
     
     load_cb_ref     = False             ! Load cf_ref from file? Otherwise define from cf_stream + inline tuning
     file_cb_ref     = "ice_data/{domain}/{grid_name}/{grid_name}_cf_ref_opt.nc"  ! Filename holding cf_ref to load 
@@ -19,19 +19,34 @@
 
 /
 
-&clim_pd_grl 
+&set_grl_pd
+    init_topo_path  = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO-M17.nc"
+    pd_topo_path      = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO-M17.nc"
+    pd_tsrf_path      = "ice_data/{domain}/{grid_name}/{grid_name}_MARv3.11-ERA_annmean_1961-1990.nc"
+    pd_smb_path       = "ice_data/{domain}/{grid_name}/{grid_name}_MARv3.11-ERA_annmean_1961-1990.nc"
+    pd_vel_path       = "ice_data/{domain}/{grid_name}/{grid_name}_VEL-J18.nc"
     bmb_shlf_const  = -1.0              ! [m/a] Basal mass balance of ice shelves
     dT_ann          = 0.0               ! [K]  Temperature anomaly (atm)
     z_sl            = 0.0               ! [m] Sea level relative to present-day 
 /
 
-&clim_pd_ant 
+&set_ant_pd
+    init_topo_path  = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO-BedMachine.nc"
+    pd_topo_path      = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO-BedMachine.nc"
+    pd_tsrf_path      = "ice_data/{domain}/{grid_name}/{grid_name}_RACMO23-ERAINT-HYBRID_1981-2010.nc"
+    pd_smb_path       = "ice_data/{domain}/{grid_name}/{grid_name}_RACMO23-ERAINT-HYBRID_1981-2010.nc"
+    pd_vel_path       = "ice_data/{domain}/{grid_name}/{grid_name}_VEL-R11-2.nc"
     bmb_shlf_const  = -0.2              ! [m/a] Basal mass balance of ice shelves
     dT_ann          = 0.0               ! [K]  Temperature anomaly (atm)
     z_sl            = 0.0               ! [m] Sea level relative to present-day 
 /
 
-&clim_lgm 
+&set_ant_lgm 
+    init_topo_path  = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO-BedMachine.nc"
+    pd_topo_path      = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO-BedMachine.nc"
+    pd_tsrf_path      = "ice_data/{domain}/{grid_name}/{grid_name}_RACMO23-ERAINT-HYBRID_1981-2010.nc"
+    pd_smb_path       = "ice_data/{domain}/{grid_name}/{grid_name}_RACMO23-ERAINT-HYBRID_1981-2010.nc"
+    pd_vel_path       = "ice_data/{domain}/{grid_name}/{grid_name}_VEL-R11-2.nc"
     bmb_shlf_const  = 0.0               ! [m/a] Basal mass balance of ice shelves
     dT_ann          = -10.0             ! [K] Temperature anomaly (atm)
     z_sl            = -120.0            ! [m] Sea level relative to present-day 

--- a/runme
+++ b/runme
@@ -403,7 +403,15 @@ def runjob(rundir,cmd,omp):
     # be ok in this context, see https://docs.python.org/2/library/subprocess.html#frequently-used-arguments
     #jobstatus = subp.check_call(cmd_job,shell=True)
     try:
-        jobstatus = subp.check_output(cmd_job,shell=True,stdin=None,stderr=None)
+        #jobstatus = subp.check_output(cmd_job,shell=True,stdin=None,stderr=None)
+        jobstatus = subp.Popen(
+            cmd_job,
+            shell=True,
+            stdin=subp.DEVNULL,
+            stdout=subp.DEVNULL,
+            stderr=subp.DEVNULL,
+            start_new_session=True,
+        )
     except subp.CalledProcessError as error:
         print(error)
         sys.exit() 

--- a/src/yelmo_ice.f90
+++ b/src/yelmo_ice.f90
@@ -335,7 +335,7 @@ contains
                 call set_pc_mask(pc_mask,dom%time%pc_tau,dom%tpo%now%corr%H_ice,dom%tpo%now%pred%H_ice,dom%bnd%z_bed, &
                                 dom%bnd%z_sl,dom%bnd%c%rho_ice,dom%bnd%c%rho_sw,dom%par%pc_eps, &
                                 dom%tpo%par%boundaries,dom%tpo%par%margin_flt_subgrid)
-                eta_now = calc_pc_eta(dom%time%pc_tau,mask=pc_mask)
+                eta_now = calc_pc_eta(dom%time%pc_tau,H_ice=dom%tpo%now%corr%H_ice,mask=pc_mask)
 
                 ! Save masked pc_tau for output too 
                 dom%time%pc_tau_masked = dom%time%pc_tau 

--- a/src/yelmo_timesteps.f90
+++ b/src/yelmo_timesteps.f90
@@ -272,19 +272,24 @@ end if
 
     end subroutine set_pc_mask
 
-    function calc_pc_eta(tau,mask) result(eta)
+    function calc_pc_eta(tau,H_ice,mask) result(eta)
 
         implicit none 
 
         real(wp), intent(IN) :: tau(:,:) 
-        logical,  intent(IN) :: mask(:,:) 
+        real(wp), intent(IN) :: H_ice(:,:)  ! Ice thickness (ice-sheet specific) 
+        logical,  intent(IN) :: mask(:,:)   ! General mask
         real(wp) :: eta 
 
-        real(wp), parameter :: eta_tol = 1e-8 
-
+        ! Local variables
+        integer :: i, j, nx, ny
         integer :: npts
-
-if (.TRUE.) then
+        real(wp) :: s_now
+        real(wp), parameter :: eta_tol = 1e-8 
+        real(wp), parameter :: a_tol = 1.0 ! [m]
+        real(wp), parameter :: r_tol = 1e-2 ! [--] r_tol*H = [m]
+        
+if (.FALSE.) then
         ! Calculate eta 
         eta = maxval(abs(tau),mask=mask)
 
@@ -297,11 +302,30 @@ else
     ! ajr: testing rmse(tau) instead of max(tau)
     ! So far, this works, but leads to large areas of Antarctica on the coast with large tau values.
         npts = count(mask)
-        if (npts .eq. 0) then 
-            eta = eta_tol 
-        else 
-            eta = sqrt(sum(tau**2,mask=mask)/real(npts,wp))
+        if (npts .gt. 0) then 
+            ! eta = sqrt(sum(tau**2,mask=mask)/real(npts,wp))
+            ! eta = max(eta,eta_tol)
+
+            nx = size(tau,1)
+            ny = size(tau,2)
+
+            eta = 0.0
+
+            do i = 1, nx
+            do j = 1, ny
+                s_now = a_tol + r_tol*H_ice(i,j)
+                eta = eta + (tau(i,j) / s_now)**2
+            end do
+            end do
+            
+            eta = sqrt(eta/npts)
+
             eta = max(eta,eta_tol)
+
+        else    ! npts == 0
+
+            eta = eta_tol
+
         end if
 end if 
 

--- a/tests/yelmo_initmip.f90
+++ b/tests/yelmo_initmip.f90
@@ -38,13 +38,19 @@ program yelmo_test
         logical  :: with_ice_sheet 
         character(len=56) :: equil_method
         
-        character(len=512) :: clim_nm
+        character(len=512) :: set_nm
           
         logical :: load_cb_ref 
         character(len=256) :: file_cb_ref 
 
         logical :: load_bmelt
         character(len=256) :: file_bmelt 
+
+        character(len=512) :: init_topo_path
+        character(len=512) :: pd_topo_path
+        character(len=512) :: pd_tsrf_path
+        character(len=512) :: pd_smb_path
+        character(len=512) :: pd_vel_path
 
         real(wp) :: bmb_shlf_const
         real(wp) :: dT_ann
@@ -79,7 +85,7 @@ program yelmo_test
     call nml_read(path_par,"ctrl","dtt",            ctl%dtt)                ! [yr] Main loop time step 
     call nml_read(path_par,"ctrl","with_ice_sheet", ctl%with_ice_sheet)     ! Include an active ice sheet 
     call nml_read(path_par,"ctrl","equil_method",   ctl%equil_method)       ! What method should be used for spin-up?
-    call nml_read(path_par,"ctrl","clim_nm",        ctl%clim_nm)            ! Namelist group holding climate information
+    call nml_read(path_par,"ctrl","set_nm",         ctl%set_nm)             ! Namelist group holding relevant setup (topo and climate information)
     
     call nml_read(path_par,"ctrl","load_cb_ref",    ctl%load_cb_ref)        ! Load cb_ref from file? Otherwise define from till_cf_ref + inline tuning
     call nml_read(path_par,"ctrl","file_cb_ref",    ctl%file_cb_ref)        ! Filename holding cb_ref to load 
@@ -87,10 +93,23 @@ program yelmo_test
     call nml_read(path_par,"ctrl","load_bmelt",     ctl%load_bmelt)         ! Load bmelt from file?
     call nml_read(path_par,"ctrl","file_bmelt",     ctl%file_bmelt)         ! Filename holding bmelt field to load 
         
-    ! Load climate (eg, clim_pd or clim_lgm)
-    call nml_read(path_par,ctl%clim_nm,  "bmb_shlf_const",  ctl%bmb_shlf_const)            ! [yr] Constant imposed bmb_shlf value
-    call nml_read(path_par,ctl%clim_nm,  "dT_ann",          ctl%dT_ann)                    ! [K] Temperature anomaly (atm)
-    call nml_read(path_par,ctl%clim_nm,  "z_sl",            ctl%z_sl)                      ! [m] Sea level relative to present-day
+    ! Load climate (eg, set_pd or set_lgm)
+    call nml_read(path_par,ctl%set_nm,  "init_topo_path",  ctl%init_topo_path)
+    call nml_read(path_par,ctl%set_nm,  "pd_topo_path",    ctl%pd_topo_path)
+    call nml_read(path_par,ctl%set_nm,  "pd_tsrf_path",    ctl%pd_tsrf_path)
+    call nml_read(path_par,ctl%set_nm,  "pd_smb_path",     ctl%pd_smb_path)
+    call nml_read(path_par,ctl%set_nm,  "pd_vel_path",     ctl%pd_vel_path)
+
+    ! Parse ctl filenames as needed
+    call nml_set_param(path_par, "yelmo_init_topo", "init_topo_path", ctl%init_topo_path)
+    call nml_set_param(path_par, "yelmo_data", "pd_topo_path", ctl%pd_topo_path)
+    call nml_set_param(path_par, "yelmo_data", "pd_tsrf_path", ctl%pd_tsrf_path)
+    call nml_set_param(path_par, "yelmo_data", "pd_smb_path",  ctl%pd_smb_path)
+    call nml_set_param(path_par, "yelmo_data", "pd_vel_path",  ctl%pd_vel_path)
+    
+    call nml_read(path_par,ctl%set_nm,  "bmb_shlf_const",  ctl%bmb_shlf_const)            ! [yr] Constant imposed bmb_shlf value
+    call nml_read(path_par,ctl%set_nm,  "dT_ann",          ctl%dT_ann)                    ! [K] Temperature anomaly (atm)
+    call nml_read(path_par,ctl%set_nm,  "z_sl",            ctl%z_sl)                      ! [m] Sea level relative to present-day
 
     ! Get output times
     call timeout_init(t1D,  path_par,"t1D",  "small",  ctl%time_init,ctl%time_end)
@@ -745,6 +764,87 @@ end if
         return 
 
     end subroutine scale_cf_gaussian
+
+    subroutine nml_set_param(filename, nml_group, par_name, value)
+        implicit none
+        character(len=*), intent(in) :: filename, nml_group, par_name, value
+
+        integer, parameter :: MAX_LINES = 50000
+        integer, parameter :: LINE_LEN  = 1024
+
+        character(len=LINE_LEN) :: lines(MAX_LINES)
+        character(len=LINE_LEN) :: trimmed
+        integer :: unit, io, n_lines, i, ieq
+        logical :: in_group, found
+
+        open(newunit=unit, file=trim(filename), status='old', action='read', iostat=io)
+        if (io /= 0) stop 'nml_set_param ERROR: cannot open file'
+
+        n_lines = 0
+        do
+            read(unit, '(A)', iostat=io) lines(n_lines + 1)
+            if (io /= 0) exit
+            n_lines = n_lines + 1
+        end do
+        close(unit)
+
+        in_group = .false.
+        found    = .false.
+
+        do i = 1, n_lines
+            trimmed = adjustl(lines(i))
+
+            if (.not. in_group) then
+                if (trimmed(1:1) == '&' .and. str_eq_ci(trim(trimmed(2:)), nml_group)) &
+                    in_group = .true.
+            else
+                if (trimmed(1:1) == '/') exit
+                ieq = index(trimmed, '=')
+                if (ieq > 1 .and. str_eq_ci(trim(trimmed(1:ieq-1)), par_name)) then
+                    lines(i) = " " // trim(par_name) // " = '" // trim(value) // "'"
+                    found = .true.
+                    exit
+                end if
+            end if
+        end do
+
+        if (.not. found) then
+            write(*,'(4a)') 'nml_set_param WARNING: "', trim(par_name), &
+                '" not found in group "', trim(nml_group)//'"'
+            return
+        end if
+
+        open(newunit=unit, file=trim(filename), status='replace', action='write', iostat=io)
+        if (io /= 0) stop 'nml_set_param ERROR: cannot write file'
+        do i = 1, n_lines
+            write(unit, '(A)') trim(lines(i))
+        end do
+        close(unit)
+
+    end subroutine nml_set_param
+
+    pure function str_eq_ci(a, b) result(eq)
+        implicit none
+        character(len=*), intent(in) :: a, b
+        logical :: eq
+        integer :: j, n
+        n  = len_trim(a)
+        eq = (n == len_trim(b))
+        if (.not. eq) return
+        do j = 1, n
+            eq = (lower_char(a(j:j)) == lower_char(b(j:j)))
+            if (.not. eq) return
+        end do
+    end function str_eq_ci
+
+    pure function lower_char(c) result(lc)
+        implicit none
+        character, intent(in) :: c
+        character             :: lc
+        integer               :: ic
+        ic = iachar(c)
+        lc = merge(achar(ic+32), c, ic >= iachar('A') .and. ic <= iachar('Z'))
+    end function lower_char
 
 end program yelmo_test
 


### PR DESCRIPTION
Introduction of pointwise scaling of error metric tau when calculating pc_eta:

> The scale $s_i$ should be CVODE-style mixed absolute/relative: $s_i = \text{atol} + \text{rtol} \cdot |H_i|$. Pure absolute (e.g. $s_i=1$ m) makes the norm dominated by thick interior cells; pure relative makes it dominated by thin cells. A typical setting for ice is $text{atol} \approx 1$ m, $text{rtol} \approx 10^{-3}$ to $10^{-2}$. With this scaling, the controller's target becomes simply $\tau \le 1$.

Tuning heuristic: set atol to the smallest absolute thickness change you'd accept as "negligible" (often 1–10 m for continental ice sheets), and rtol to the relative accuracy you want in the interior (typically $10^{-3}$ to $10^{-2}$. If Δt is still pinned by thin cells, raise atol; if you're losing accuracy in the interior, lower rtol.