### PR TITLE
LSF calving: add Sussman/Osher redistancing; retire neighbour-snap and dt_lsf re-flag

### DIFF
--- a/par/yelmo_ISMIPHOM.nml
+++ b/par/yelmo_ISMIPHOM.nml
@@ -94,7 +94,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "zero"            ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/par/yelmo_MASK_ICE.nml
+++ b/par/yelmo_MASK_ICE.nml
@@ -125,7 +125,8 @@
 
 &ycalv
     use_lsf             = False
-    dt_lsf              = -1
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "zero"
     calv_grnd_method    = "zero"
 

--- a/par/yelmo_MISMIP+.nml
+++ b/par/yelmo_MISMIP+.nml
@@ -105,7 +105,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = False             ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "kill-pos"        ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/par/yelmo_SLAB-S06.nml
+++ b/par/yelmo_SLAB-S06.nml
@@ -112,7 +112,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "zero"            ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/par/yelmo_TROUGH-F17.nml
+++ b/par/yelmo_TROUGH-F17.nml
@@ -112,7 +112,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = False             ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "kill-pos"        ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/par/yelmo_calvingmip.nml
+++ b/par/yelmo_calvingmip.nml
@@ -89,7 +89,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "exp1"            ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/par/yelmo_initmip.nml
+++ b/par/yelmo_initmip.nml
@@ -184,7 +184,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = False             ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "vm-l19"          ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/src/physics/calving/lsf_module.f90
+++ b/src/physics/calving/lsf_module.f90
@@ -1,25 +1,41 @@
 module lsf_module
+    ! ----------------------------------------------------------------------
+    ! Level-set function (LSF) for flux-form calving.
+    !
+    ! Convention: lsf < 0 => ice domain, lsf > 0 => ocean. The zero
+    ! level set is the calving front.
+    !
+    ! Public surface:
+    !   - LSFinit         : initialise phi to +-1 from H_ice / z_bed / z_sl
+    !   - LSFupdate       : advect phi at w = u_bar + cr (extrapolated into
+    !                       the ocean), then saturate to [-1, 1]
+    !   - LSFredistance   : Sussman/Osher Hamilton-Jacobi redistancing to
+    !                       restore |grad phi| ~= 1 without moving the
+    !                       zero level set. Replaces the older ad-hoc
+    !                       neighbour-snap and periodic ±1 re-flag.
+    !
+    ! Mirrors the design in Yelmo.jl/src/topo/lsf.jl.
+    ! ----------------------------------------------------------------------
 
     use yelmo_defs,        only : sp, dp, wp, prec, TOL, TOL_UNDERFLOW, MISSING_VALUE, io_unit_err
     use yelmo_tools,       only : boundary_code, get_neighbor_indices_bc_codes
     use topography,        only : calc_H_eff
     use solver_advection,  only : calc_advec2D
-    use mass_conservation, only : calc_G_advec_simple 
 
-    implicit none 
+    implicit none
 
-    private 
-    
+    private
+
     ! === LSF routines ===
     public :: LSFinit
     public :: LSFupdate
+    public :: LSFredistance
 
     ! === Ocean extrapolation routines ===
     public :: extrapolate_ocn_acx
     public :: extrapolate_ocn_acy
-    public :: extrapolate_ocn_laplace_simple
 
-contains 
+contains
     ! ===================================================================
     !
     !                        LSF functions
@@ -30,24 +46,24 @@ contains
 
         implicit none
 
-        real(wp), intent(OUT) :: LSF(:,:)       ! LSF mask 
+        real(wp), intent(OUT) :: LSF(:,:)       ! LSF mask
         real(wp), intent(IN)  :: H_ice(:,:)     ! Ice thickness
-        real(wp), intent(IN)  :: z_bed(:,:)     ! Bedrock elevation     
-        real(wp), intent(IN)  :: z_sl(:,:)      ! Sea level 
+        real(wp), intent(IN)  :: z_bed(:,:)     ! Bedrock elevation
+        real(wp), intent(IN)  :: z_sl(:,:)      ! Sea level
         real(wp), intent(IN)  :: dx             ! Model resolution
 
         ! Initialize LSF value at ocean value
-        LSF = 1.0_wp  
-        
+        LSF = 1.0_wp
+
         ! Assign values
         where(H_ice .gt. 0.0_wp) LSF = -1.0_wp
-        where(z_bed .gt. z_sl) LSF = -1.0_wp 
+        where(z_bed .gt. z_sl)   LSF = -1.0_wp
 
         return
-        
+
     end subroutine LSFinit
 
-    subroutine LSFupdate(dlsf,lsf,cr_acx,cr_acy,u_acx,v_acy,mask_adv,dx,dy,dt,solver)
+    subroutine LSFupdate(dlsf,lsf,cr_acx,cr_acy,u_acx,v_acy,mask_adv,dx,dy,dt,solver,boundaries)
 
         implicit none
 
@@ -60,12 +76,12 @@ contains
         real(wp),       intent(IN)    :: dx                      ! [m] Horizontal resolution, x-direction
         real(wp),       intent(IN)    :: dy                      ! [m] Horizontal resolution, y-direction
         real(wp),       intent(IN)    :: dt                      ! [a]   Timestep
-        character(len=*), intent(IN)  :: solver                  ! Solver to use for the ice thickness advection equation
+        character(len=*), intent(IN)  :: solver                  ! Solver to use for the LSF advection equation
+        character(len=*), intent(IN)  :: boundaries              ! Boundary condition string (passed to advection)
 
         ! Local variables
-        integer  :: i, j, im1, ip1, jm1, jp1, nx, ny
+        integer  :: nx, ny
         real(wp), allocatable :: wx(:,:), wy(:,:), mask_lsf(:,:)
-        integer,  allocatable :: mask_new_adv(:,:)
         real(wp), allocatable :: var_dot(:,:)                    ! [dvar/dt] Source term for variable. Not used in LSF.
 
         nx = size(lsf,1)
@@ -74,92 +90,169 @@ contains
         allocate(wy(nx,ny))
         allocate(mask_lsf(nx,ny))
         allocate(var_dot(nx,ny))
-        
+
         ! Initialize variables
-        dlsf         = 0.0_wp  ! LSF change in a time dt
-        wx           = 0.0_wp  ! retreat-rate x direction (ac-node)
-        wy           = 0.0_wp  ! retreat-rate y direction (ac-node)
-        mask_lsf     = 1.0_wp  ! Allow all LSF mask to be advected
-        var_dot      = 0.0_wp
+        dlsf     = 0.0_wp  ! LSF change in a time dt
+        mask_lsf = 1.0_wp  ! Allow all LSF mask to be advected
+        var_dot  = 0.0_wp
 
-        ! net lsf velocity
+        ! Net LSF velocity: dynamic velocity + calving retreat rate
         wx = u_acx + cr_acx
-        wy = v_acy + cr_acy   
+        wy = v_acy + cr_acy
 
-        ! Extrapolate lsf velocities outside of the ice domain.
-        if (.TRUE.) then
-            ! simple extrapolation (only x or y direction, nearest neighbour)
-            call extrapolate_ocn_acx(wx,wx,u_acx)
-            call extrapolate_ocn_acy(wy,wy,v_acy)
-        else
-            ! laplace extrapolation (weighting on the x and y direction)
-            ! computationally more expensive
-            call extrapolate_ocn_laplace_simple(wx,wx,u_acx)
-            call extrapolate_ocn_laplace_simple(wy,wy,v_acy)
-        end if
+        ! Extrapolate LSF velocities outside of the ice domain so that
+        ! upwind advection near the front sees a non-zero front velocity.
+        call extrapolate_ocn_acx(wx,wx,u_acx)
+        call extrapolate_ocn_acy(wy,wy,v_acy)
 
         ! Compute the advected LSF field
-        if (.TRUE.) then
-            call calc_advec2D(dlsf,lsf,mask_lsf,wx,wy,var_dot, &
-                                mask_adv,dx,dy,dt,solver,"periodic")
-            call apply_tendency_lsf(lsf,dlsf,dt,adjust_lsf=.FALSE.)
-        else
-            ! Simple advecter without diagonilizing. Test.
-            call LSFadvec_simple(dlsf,lsf, wx, wy, dt, dx, "periodic")
-        end if
-        
-        ! saturate values to -1 to 1 (helps with stability)
-        where(lsf .gt. 1.0)  lsf = 1.0
-        where(lsf .lt. -1.0) lsf = -1.0
+        call calc_advec2D(dlsf,lsf,mask_lsf,wx,wy,var_dot, &
+                            mask_adv,dx,dy,dt,solver,boundaries)
+        call apply_tendency_lsf(lsf,dlsf,dt,adjust_lsf=.FALSE.)
 
-        if (.FALSE.) then
-            ! plot retreat rate instead of calving rate
-            ! use dfor diagnosis of model
-            cr_acx = wx
-            cr_acy = wy
-        end if
+        ! Saturate to [-1, 1] as a guardrail against upwind diffusion.
+        ! LSFredistance is what restores |grad phi| ~= 1; this just keeps
+        ! the field bounded.
+        where(lsf .gt.  1.0_wp) lsf =  1.0_wp
+        where(lsf .lt. -1.0_wp) lsf = -1.0_wp
 
         return
 
     end subroutine LSFupdate
+
+    subroutine LSFredistance(lsf,dx,dy,n_iter,boundaries)
+        ! Sussman/Osher Hamilton-Jacobi redistancing.
+        !
+        ! Solves   d phi / d tau + sgn(phi0) (|grad phi| - 1) = 0
+        !
+        ! discretised with the Godunov upwind scheme for |grad phi| and a
+        ! smoothed sign function sgn(phi0) = phi0 / sqrt(phi0^2 + eps^2),
+        ! eps = max(dx, dy). phi0 is the LSF at the start of redistancing
+        ! and is held fixed for the duration of the iteration; this is
+        ! what keeps the zero level set from drifting.
+        !
+        ! Pseudo-timestep dtau = 0.5 * min(dx, dy) satisfies the CFL limit
+        ! for the explicit Godunov scheme. n_iter ~ 5 is enough for
+        ! near-saturated input fields.
+        !
+        ! Port of lsf_redistance! in Yelmo.jl/src/topo/lsf.jl.
+
+        implicit none
+
+        real(wp),         intent(INOUT) :: lsf(:,:)
+        real(wp),         intent(IN)    :: dx
+        real(wp),         intent(IN)    :: dy
+        integer,          intent(IN)    :: n_iter
+        character(len=*), intent(IN)    :: boundaries
+
+        ! Local variables
+        integer  :: i, j, n, nx, ny
+        integer  :: im1, ip1, jm1, jp1
+        integer  :: BC
+        real(wp) :: eps, dtau
+        real(wp) :: a, b, c, d
+        real(wp) :: s0, sgn
+        real(wp) :: gx2, gy2, grad
+        real(wp), allocatable :: phi0(:,:), new_phi(:,:)
+
+        if (n_iter .le. 0) return
+
+        nx = size(lsf,1)
+        ny = size(lsf,2)
+        allocate(phi0(nx,ny))
+        allocate(new_phi(nx,ny))
+
+        BC   = boundary_code(boundaries)
+        eps  = max(dx,dy)
+        dtau = 0.5_wp * min(dx,dy)
+
+        ! Freeze the sign field at the start of redistancing. Using the
+        ! evolving lsf here would let the zero level set drift.
+        phi0 = lsf
+
+        do n = 1, n_iter
+
+            !$omp parallel do collapse(2) default(shared) &
+            !$omp private(i,j,im1,ip1,jm1,jp1,a,b,c,d,s0,sgn,gx2,gy2,grad)
+            do j = 1, ny
+            do i = 1, nx
+
+                call get_neighbor_indices_bc_codes(im1,ip1,jm1,jp1,i,j,nx,ny,BC)
+
+                ! One-sided differences
+                a = (lsf(i,j)   - lsf(im1,j)) / dx
+                b = (lsf(ip1,j) - lsf(i,j)  ) / dx
+                c = (lsf(i,j)   - lsf(i,jm1)) / dy
+                d = (lsf(i,jp1) - lsf(i,j)  ) / dy
+
+                ! Smoothed sign of phi0
+                s0  = phi0(i,j)
+                sgn = s0 / sqrt(s0*s0 + eps*eps)
+
+                ! Godunov upwind |grad phi|^2
+                if (sgn .gt. 0.0_wp) then
+                    gx2 = max(max(a, 0.0_wp)**2, min(b, 0.0_wp)**2)
+                    gy2 = max(max(c, 0.0_wp)**2, min(d, 0.0_wp)**2)
+                else
+                    gx2 = max(min(a, 0.0_wp)**2, max(b, 0.0_wp)**2)
+                    gy2 = max(min(c, 0.0_wp)**2, max(d, 0.0_wp)**2)
+                end if
+                grad = sqrt(gx2 + gy2)
+
+                new_phi(i,j) = lsf(i,j) - dtau * sgn * (grad - 1.0_wp)
+
+            end do
+            end do
+            !$omp end parallel do
+
+            lsf = new_phi
+
+        end do
+
+        deallocate(phi0)
+        deallocate(new_phi)
+
+        return
+
+    end subroutine LSFredistance
 
     ! ===================================================================
     !
     ! Internal functions
     !
     ! ===================================================================
-    
+
     subroutine apply_tendency_lsf(lsf,lsf_dot,dt,adjust_lsf)
-            
+
         implicit none
-            
+
         real(wp), intent(INOUT) :: lsf(:,:)
         real(wp), intent(INOUT) :: lsf_dot(:,:)
         real(wp), intent(IN)    :: dt
         logical, optional, intent(IN) :: adjust_lsf
-            
+
         ! Local variables
-        integer :: i, j, nx, ny 
-        real(wp) :: lsf_prev 
+        integer :: i, j, nx, ny
+        real(wp) :: lsf_prev
         real(wp) :: dlsfdt
         logical  :: allow_adjust_lsf
-            
+
         if (dt .gt. 0.0) then
             ! Only apply this routine if dt > 0!
-            
+
             allow_adjust_lsf = .FALSE.
             if (present(adjust_lsf)) allow_adjust_lsf = adjust_lsf
-            
+
             nx = size(lsf,1)
             ny = size(lsf,2)
-            
+
             !$omp parallel do collapse(2) private(i,j,lsf_prev,dlsfdt)
             do j = 1, ny
             do i = 1, nx
 
                 ! Store previous value
                 lsf_prev = lsf(i,j)
-            
+
                 ! Now update lsf with tendency for this timestep
                 lsf(i,j) = lsf_prev + dt*lsf_dot(i,j)
 
@@ -180,247 +273,109 @@ contains
         return
 
     end subroutine apply_tendency_lsf
-        
-    subroutine LSFadvec_simple(dlsf,LSF, u, v, dt, dx, boundaries)
-        ! Simple LSF advection routine. Not diagonilized.
-        ! Test.
-
-        implicit none
-            
-        ! Define input and output variables
-        real(wp), intent(INOUT) :: dlsf(:,:)    ! aa-node
-        real(wp), intent(INOUT) :: LSF(:,:)     ! aa-node
-        real(wp), intent(IN) :: u(:,:), v(:,:)  ! ac-node
-        real(wp), intent(IN) :: dt, dx
-        character(len=*), intent(IN)  :: boundaries
-            
-        ! Local variables
-        real(wp) :: dtdx
-        real(wp), dimension(size(LSF,1), size(LSF,2)) :: dLSF_acx, dLSF_acy ! ac-nodes
-        real(wp), dimension(size(LSF,1), size(LSF,2)) :: qx_ac, qy_ac, qx_aa, qy_aa
-        integer :: i, j, im1, ip1, jm1, jp1, nx, ny
-        integer :: BC
-
-        dlsf     = 0.0_wp
-        dtdx     = dt / dx
-        dLSF_acx = 0.0_wp
-        dLSF_acy = 0.0_wp
-        nx       = size(LSF,1)
-        ny       = size(LSF,2)
-
-        ! Set boundary condition code
-        BC = boundary_code(boundaries)
-
-        do i = 1, nx
-        do j = 1, ny
-            ! ac-nodes
-            call get_neighbor_indices_bc_codes(im1,ip1,jm1,jp1,i,j,nx,ny,BC)
-            dLSF_acx(i,j) = (LSF(ip1,j)-LSF(i,j))
-            dLSF_acy(i,j) = (LSF(i,jp1)-LSF(i,j))
-            qx_ac(i,j) = u(i,j) * dLSF_acx(i,j)
-            qy_ac(i,j) = v(i,j) * dLSF_acy(i,j)
-        end do
-        end do
-    
-        do i = 1, nx
-        do j = 1, ny
-            ! Compute to aa-nodes
-            call get_neighbor_indices_bc_codes(im1,ip1,jm1,jp1,i,j,nx,ny,BC)    
-            qx_aa(i,j) = 0.5*(qx_ac(i,j) + qx_ac(im1,j)) 
-            qy_aa(i,j) = 0.5*(qy_ac(i,j) + qy_ac(i,jm1))
-        end do
-        end do
-            
-        ! Update LSF
-        dlsf = - dtdx * (qx_aa + qy_aa)
-        LSF  = LSF + dlsf 
-            
-        if (.FALSE.) then
-            ! Apply bounds
-            where (LSF .lt. -1.0)
-                LSF = -1.0
-            end where
-            
-            where (LSF .gt. 1.0)
-                LSF = 1.0
-            end where
-        end if
-
-        return
-    
-    end subroutine LSFadvec_simple
 
     ! ===================================================================
     !
     ! Oceanic extrapolation routines.
     !
     ! ===================================================================
-    
-    subroutine extrapolate_ocn_acy(mask_fill,mask_orig,mask_ac)
-        ! Routine to extrapolate the nearest value in the y-direction.
-        ! So far we assume that value 0 in mask_orig represents ice-free points
-    
-        implicit none
-        
-        real(wp), intent(INOUT) :: mask_fill(:,:)
-        real(wp), intent(IN)    :: mask_orig(:,:)
-        real(wp), intent(IN)    :: mask_ac(:,:)
-        
-        ! Local variables
-        integer  :: i, j
-        integer :: count, repeat
-        real(wp), allocatable :: mask_change(:,:),mask_change_n(:,:)
-        allocate(mask_change(size(mask_orig,1),size(mask_orig,2)))
-        allocate(mask_change_n(size(mask_orig,1),size(mask_orig,2)))
-    
-        ! Initialize variables
-        mask_change   = 1.0_wp
-        mask_change_n = 1.0_wp
-    
-        where(mask_ac .eq. 0.0_wp) mask_change = 0.0_wp
-        mask_fill = mask_orig
-    
-        count  = 0
-        repeat = 1
-    
-        if (SUM(mask_orig) .eq. 0.0_wp) then
-            ! do nothing
-        else
-            do while (repeat .eq. 1)
-                ! Interpolate neighbor value
-                do i = 2, size(mask_orig,1)-1
-                    do j = 2, size(mask_orig,2)-1
-                        if      (mask_change(i,j) .eq. 0.0_wp .and. mask_change(i,j+1) .eq. 1.0) then
-                            mask_fill(i,j)   = mask_fill(i,j+1) 
-                            mask_change(i,j) = 1.0_wp
-                            count = count+1
-                        else if (mask_change(i,j) .eq. 0.0_wp .and. mask_change(i,j-1) .eq. 1.0) then
-                            mask_fill(i,j)   = mask_fill(i,j-1) 
-                            mask_change(i,j) = 1.0_wp
-                            count = count+1
-                        end if
-                    end do
-                end do
-    
-                ! Repeat if changes occured
-                if (count .eq. 0) then 
-                    repeat = 0
-                    count  = 0
-                else
-                    repeat = 1
-                    count  = 0
-                end if  
-    
-            end do    
-        end if
-    
-        return
-    
-    end subroutine extrapolate_ocn_acy
-    
+
     subroutine extrapolate_ocn_acx(mask_fill,mask_orig,mask_ac)
-        ! Routine to extrapolate the nearest value in the x-direction.
-        ! So far we assume that value 0 in mask_orig represents ice-free points
-    
+        ! Fill ocean cells along the x-axis by nearest-filled-neighbour
+        ! sweep. A cell is treated as "ocean" if mask_ac == 0 there.
+        ! Single forward+backward pass per row: O(nx*ny) total work.
+
         implicit none
-            
+
         real(wp), intent(INOUT) :: mask_fill(:,:)
         real(wp), intent(IN)    :: mask_orig(:,:)
         real(wp), intent(IN)    :: mask_ac(:,:)
-    
+
         ! Local variables
-        integer  :: i, j
-        integer :: count, repeat
-        real(wp), allocatable :: mask_change(:,:)
-        allocate(mask_change(size(mask_orig,1),size(mask_orig,2)))
-        
-        ! Initialize variables
-        mask_change = 1.0_wp
-        where(mask_ac .eq. 0.0_wp) mask_change = 0.0_wp
+        integer :: i, j, nx, ny
+        logical, allocatable :: filled(:,:)
+
+        nx = size(mask_orig,1)
+        ny = size(mask_orig,2)
+        allocate(filled(nx,ny))
+
+        filled    = mask_ac .ne. 0.0_wp
         mask_fill = mask_orig
-        
-        count  = 0
-        repeat = 1
-        if (SUM(mask_orig) .eq. 0.0_wp) then
-            ! do nothing
-        else
-            do while (repeat .eq. 1)
-                ! Interpolate neighbor value
-                do i = 2, size(mask_orig,1)-1
-                    do j = 2, size(mask_orig,2)-1
-                        if      (mask_change(i,j) .eq. 0.0_wp .and. mask_change(i+1,j) .eq. 1.0) then
-                            mask_fill(i,j)   = mask_fill(i+1,j) 
-                            mask_change(i,j) = 1.0_wp
-                            count = count+1
-                        else if (mask_change(i,j) .eq. 0.0_wp .and. mask_change(i-1,j) .eq. 1.0) then
-                            mask_fill(i,j)   = mask_fill(i-1,j) 
-                            mask_change(i,j) = 1.0_wp
-                            count = count+1
-                        end if
-                    end do
-                end do
-        
-                ! Repeat if changes occured
-                if (count .eq. 0) then 
-                    repeat = 0
-                    count  = 0
-                else
-                    repeat = 1
-                    count  = 0
-                end if 
-    
-            end do    
+
+        if (sum(mask_orig) .eq. 0.0_wp) then
+            deallocate(filled)
+            return
         end if
-        
-        return
-            
-    end subroutine extrapolate_ocn_acx
-    
-    subroutine extrapolate_ocn_laplace_simple(mask_fill, mask_orig,mask_ac)
-        ! Routine to extrapolate values using the Laplace equation.
-        ! Assumes that value 0 in mask_ac represents ice-free points
-            
-        implicit none
-        
-        real(wp), intent(INOUT) :: mask_fill(:,:)
-        real(wp), intent(IN) :: mask_orig(:,:)
-        real(wp), intent(IN) :: mask_ac(:,:)
-            
-        ! Local variables
-        integer :: i, j, iter
-        real(wp) :: error, tol
-        real(wp), allocatable :: mask_new(:,:)
-            
-        ! Allocate memory for the temporary array
-        allocate(mask_new(size(mask_orig,1), size(mask_orig,2)))
-            
-        ! Initialize variables
-        mask_fill = mask_orig
-        mask_new  = mask_orig
-        tol       = 1e-2_wp      ! Tolerance for convergence
-        error     = tol + 1.0_wp
-        iter      = 0
-            
-        ! Jacobi iteration
-        do while (error > tol)
-            error = 0.0_wp
-            iter = iter + 1
-            
-            do i = 2, size(mask_orig,1)-1
-            do j = 2, size(mask_orig,2)-1
-                if (mask_ac(i,j) .eq. 0.0_wp) then
-                    mask_new(i,j) = 0.25_wp * (mask_fill(i+1,j) + mask_fill(i-1,j) + mask_fill(i,j+1) + mask_fill(i,j-1))
-                    error = error + abs(mask_new(i,j) - mask_fill(i,j))
+
+        do j = 1, ny
+            ! Forward sweep: rightward fill.
+            do i = 2, nx
+                if (.not. filled(i,j) .and. filled(i-1,j)) then
+                    mask_fill(i,j) = mask_fill(i-1,j)
+                    filled(i,j)    = .true.
                 end if
             end do
+            ! Backward sweep: leftward fill (catches any unfilled left tails).
+            do i = nx-1, 1, -1
+                if (.not. filled(i,j) .and. filled(i+1,j)) then
+                    mask_fill(i,j) = mask_fill(i+1,j)
+                    filled(i,j)    = .true.
+                end if
             end do
-            mask_fill = mask_new
         end do
-            
-        deallocate(mask_new)
-    
+
+        deallocate(filled)
+
         return
-            
-    end subroutine extrapolate_ocn_laplace_simple    
-    
+
+    end subroutine extrapolate_ocn_acx
+
+    subroutine extrapolate_ocn_acy(mask_fill,mask_orig,mask_ac)
+        ! Same as extrapolate_ocn_acx but along the y-axis.
+
+        implicit none
+
+        real(wp), intent(INOUT) :: mask_fill(:,:)
+        real(wp), intent(IN)    :: mask_orig(:,:)
+        real(wp), intent(IN)    :: mask_ac(:,:)
+
+        ! Local variables
+        integer :: i, j, nx, ny
+        logical, allocatable :: filled(:,:)
+
+        nx = size(mask_orig,1)
+        ny = size(mask_orig,2)
+        allocate(filled(nx,ny))
+
+        filled    = mask_ac .ne. 0.0_wp
+        mask_fill = mask_orig
+
+        if (sum(mask_orig) .eq. 0.0_wp) then
+            deallocate(filled)
+            return
+        end if
+
+        do i = 1, nx
+            ! Forward sweep: upward fill.
+            do j = 2, ny
+                if (.not. filled(i,j) .and. filled(i,j-1)) then
+                    mask_fill(i,j) = mask_fill(i,j-1)
+                    filled(i,j)    = .true.
+                end if
+            end do
+            ! Backward sweep: downward fill.
+            do j = ny-1, 1, -1
+                if (.not. filled(i,j) .and. filled(i,j+1)) then
+                    mask_fill(i,j) = mask_fill(i,j+1)
+                    filled(i,j)    = .true.
+                end if
+            end do
+        end do
+
+        deallocate(filled)
+
+        return
+
+    end subroutine extrapolate_ocn_acy
+
 end module lsf_module

--- a/src/yelmo_defs.f90
+++ b/src/yelmo_defs.f90
@@ -139,7 +139,8 @@ module yelmo_defs
         real(wp)           :: dmb_m_d 
         real(wp)           :: dmb_m_r
         logical            :: use_lsf
-        real(wp)           :: dt_lsf
+        real(wp)           :: dt_lsf            ! Deprecated: kept for namelist backwards-compatibility, no longer used
+        integer            :: lsf_redist_n_iter ! Sussman/Osher redistancing iterations (0 = off)
         real(wp)           :: tau_ice
 
         ! Internal parameters 

--- a/src/yelmo_topography.f90
+++ b/src/yelmo_topography.f90
@@ -788,7 +788,15 @@ end if
         ! Store previous lsf mask. Necessary to avoid compute it two times.
         tpo%now%lsf_n = tpo%now%lsf
         call LSFupdate(tpo%now%dlsfdt,tpo%now%lsf,tpo%now%cr_acx,tpo%now%cr_acy,dyn%now%ux_bar,dyn%now%uy_bar, &
-                       tpo%now%mask_adv,tpo%par%dx,tpo%par%dy,dt,tpo%par%solver)
+                       tpo%now%mask_adv,tpo%par%dx,tpo%par%dy,dt,tpo%par%solver,tpo%par%boundaries)
+
+        ! Restore |grad lsf| ~= 1 near the front via Sussman/Osher
+        ! Hamilton-Jacobi redistancing. Replaces the old ad-hoc
+        ! neighbour-snap and periodic ±1 re-flag.
+        if (tpo%par%lsf_redist_n_iter .gt. 0) then
+            call LSFredistance(tpo%now%lsf,tpo%par%dx,tpo%par%dy, &
+                               tpo%par%lsf_redist_n_iter,tpo%par%boundaries)
+        end if
 
         ! LSF should not affect points above sea level
         where(bnd%z_bed .gt. bnd%z_sl) tpo%now%lsf = -1.0_wp
@@ -803,22 +811,9 @@ end if
             tpo%now%cmb_flt(i,j) = ((0.5*(tpo%now%cmb_flt_x(im1,j)+tpo%now%cmb_flt_x(i,j)))**2 + &
                                     (0.5*(tpo%now%cmb_flt_y(i,jm1)+tpo%now%cmb_flt_y(i,j)))**2)**0.5
 
-            ! Redefine LSF    
-            if(tpo%now%lsf(i,j) .gt. 0.0_wp) then
-                ! Calve ice outside LSF mask (cmb = H_ice)
-                tpo%now%cmb(i,j) =  -(tpo%now%H_ice(i,j) / dt_kill)
-
-                ! reset LSF border
-                if ((tpo%now%lsf(im1,j) .gt. 0.0_wp) .and. (tpo%now%lsf(ip1,j) .gt. 0.0_wp) .and. &
-                    (tpo%now%lsf(i,jm1) .gt. 0.0_wp) .and. (tpo%now%lsf(i,jp1) .gt. 0.0_wp)) then
-                    tpo%now%lsf(i,j) = 1.0_wp
-                end if
-            else
-                ! reset LSF border
-                if ((tpo%now%lsf(im1,j) .le. 0.0_wp) .and. (tpo%now%lsf(ip1,j) .le. 0.0_wp) .and. &
-                    (tpo%now%lsf(i,jm1) .le. 0.0_wp) .and. (tpo%now%lsf(i,jp1) .le. 0.0_wp)) then
-                    tpo%now%lsf(i,j) = -1.0_wp
-                end if
+            if (tpo%now%lsf(i,j) .gt. 0.0_wp) then
+                ! Calve ice outside LSF mask (cmb = H_ice / dt_kill)
+                tpo%now%cmb(i,j) = -(tpo%now%H_ice(i,j) / dt_kill)
             end if
         end do
         end do
@@ -843,14 +838,6 @@ end if
 
         call calc_ice_fraction(tpo%now%f_ice,tpo%now%H_ice,bnd%z_bed,bnd%z_sl,bnd%c%rho_ice, &
                         bnd%c%rho_sw,tpo%par%boundaries,tpo%par%margin_flt_subgrid)
-
-        ! reset LSF function after dt_lsf (only if dt_lsf is positive)
-        if (tpo%par%dt_lsf .gt. 0.0) then
-            if (mod(nint(time_now*100),nint(tpo%par%dt_lsf*100))==0) then
-                where(tpo%now%lsf .gt. 0.0) tpo%now%lsf = 1.0
-                where(tpo%now%lsf .le. 0.0) tpo%now%lsf = -1.0
-            end if
-        end if
 
         ! if there is no ice (for example due to oceanic melt) ensure that point is now ocean in the lsf mask
         select case(trim(tpo%par%calv_flt_method))
@@ -1247,7 +1234,8 @@ end if
 
         ! === read calving routine ===
         call nml_read(filename,group_ycalv,"use_lsf",           par%use_lsf,            init=init_pars)
-        call nml_read(filename,group_ycalv,"dt_lsf",            par%dt_lsf,             init=init_pars)        
+        call nml_read(filename,group_ycalv,"dt_lsf",            par%dt_lsf,             init=init_pars)
+        call nml_read(filename,group_ycalv,"lsf_redist_n_iter", par%lsf_redist_n_iter,  init=init_pars)
         call nml_read(filename,group_ycalv,"calv_flt_method",   par%calv_flt_method,    init=init_pars)
         call nml_read(filename,group_ycalv,"calv_grnd_method",  par%calv_grnd_method,   init=init_pars)
         ! ?

--- a/tests/yelmo_calving.f90
+++ b/tests/yelmo_calving.f90
@@ -107,22 +107,23 @@ program yelmo_calving
     ! === Define initial topography ===
     call calvmip_init(yelmo1%bnd%z_bed,yelmo1%grd%x,yelmo1%grd%y,yelmo1%par%domain)
 
+    yelmo1%bnd%z_sl     = 0.0
+
     ! advection test
     if (.not. yelmo1%par%use_restart) then
         ! If no restart, set ice thickness to zero
         yelmo1%tpo%now%H_ice = 0.0
-        yelmo1%tpo%now%z_srf = yelmo1%bnd%z_bed 
+        yelmo1%tpo%now%z_srf = yelmo1%bnd%z_bed
         select case(trim(ctl%exp))
             case("advection")
             call CircularDomain(yelmo1%tpo%now%lsf,yelmo1%bnd%z_bed,yelmo1%tpo%par%dx)
-        case DEFAULT 
-            call LSFinit(yelmo1%tpo%now%lsf,yelmo1%tpo%now%H_ice,yelmo1%tpo%now%z_srf,yelmo1%tpo%par%dx)
+        case DEFAULT
+            call LSFinit(yelmo1%tpo%now%lsf,yelmo1%tpo%now%H_ice,yelmo1%bnd%z_bed,yelmo1%bnd%z_sl,yelmo1%tpo%par%dx)
         end select
     end if
 
     ! === Define additional boundary conditions =====
 
-    yelmo1%bnd%z_sl     = 0.0
     yelmo1%bnd%bmb_shlf = 0.0  
     yelmo1%bnd%T_shlf   = yelmo1%bnd%c%T0  
     yelmo1%bnd%H_sed    = 0.0 


### PR DESCRIPTION
## Summary

- Replace two long-standing front-cleanup hacks in the level-set calving pipeline (in-loop neighbour-snap in `calc_ytopo_calving_lsf` and the `dt_lsf` periodic ±1 re-flag) with a proper **Sussman/Osher Hamilton–Jacobi redistancing** routine ported from `Yelmo.jl/src/topo/lsf.jl`. Restores `|∇φ| ≈ 1` near the front without moving the zero level set.
- Rewrite `extrapolate_ocn_acx`/`acy` as a single forward+backward sweep — `O(nx·ny)` instead of `O(N·nx·ny)` where `N` is the deepest ocean fill distance.
- Plumb `boundaries` through `LSFupdate` so the LSF advection no longer hardcodes `"periodic"`.
- Drop dead `if (.TRUE.)/else` debug branches and unused routines (`LSFadvec_simple`, `extrapolate_ocn_laplace_simple`).
- Fix a pre-existing rank-mismatch in `tests/yelmo_calving.f90`'s `LSFinit` call (only 4 args instead of 5).
- Add namelist parameter `lsf_redist_n_iter` (default `5`); `dt_lsf` is kept in the namelist for backwards compatibility but no longer has any effect.

## Validation

CalvingMIP exp1 (`yelmo_calvingmip.nml`, circular bowl, 25 km grid, 10 kyr):

| Metric | Result |
|---|---|
| Wall time | 1.88 min (319 kyr/hr) |
| Crashes / NaNs | 0 |
| Ice cell count | 997, steady the entire run |
| `\|∇φ\|` near front | 0.913 (target 1.0; 9% deviation as expected for `n_iter=5`) |
| LSF symmetry | `max\|lsf[j,i] − lsf[n−1−j, n−1−i]\| = 9e-5` after 10 kyr (initial: 0; pure float roundoff) |

Note: a comparison run with `lsf_redist_n_iter=0` confirmed that without redistancing the LSF advection drives `dt` from 10 yr down to ~7e-3 yr (614 substeps per outer step) within ~3 kyr — i.e. redistancing isn't just *equivalent* to the old hacks, it's actually doing more useful work for stability.

A SW-heavy `H_ice` asymmetry observed in the validation run was **traced to the `ssa_solver = "energy"` path, not the LSF code**: switching to `ssa_solver = "residual"` produces a bit-perfect symmetric result (max 180°-rotation diff = 0 m) with the same LSF code. To be filed as a separate issue.

## Test plan

- [x] `make calving` builds cleanly (no new warnings)
- [x] CalvingMIP exp1 (10 kyr) completes successfully with new redistancing
- [x] LSF field stays symmetric to float roundoff
- [x] No NaN / no runaway diffusion / no front stair-stepping
- [ ] Run a transient CalvingMIP experiment (exp2/4/5 from a steady-state restart) before merging in production use