### PR TITLE
par-gmd: add missing nml_ycalv mapping and lsf_redist_n_iter

### DIFF
--- a/par-gmd/yelmo_Antarctica.nml
+++ b/par-gmd/yelmo_Antarctica.nml
@@ -39,6 +39,7 @@
     phys_const      = "Earth"
     experiment      = "None"       
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"
@@ -111,7 +112,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "vm-m16"          ! "zero", "stress-b12", "vm-m16"
     

--- a/par-gmd/yelmo_EISMINT_expa.nml
+++ b/par-gmd/yelmo_EISMINT_expa.nml
@@ -25,6 +25,7 @@
     phys_const      = "EISMINT"
     experiment      = "EISMINT"         ! "None", "EISMINT", "MISMIP3D", "BUELER"  to apply special boundary conditions   
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"
@@ -97,7 +98,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "zero"            ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/par-gmd/yelmo_EISMINT_expf.nml
+++ b/par-gmd/yelmo_EISMINT_expf.nml
@@ -25,6 +25,7 @@
     phys_const      = "EISMINT"
     experiment      = "EISMINT"         ! "None", "EISMINT", "MISMIP3D", "BUELER"  to apply special boundary conditions   
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"
@@ -97,7 +98,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "zero"            ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/par-gmd/yelmo_EISMINT_moving.nml
+++ b/par-gmd/yelmo_EISMINT_moving.nml
@@ -25,6 +25,7 @@
     phys_const      = "EISMINT"
     experiment      = "EISMINT"         ! "None", "EISMINT", "MISMIP3D", "BUELER"  to apply special boundary conditions   
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"
@@ -97,7 +98,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "zero"            ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/par-gmd/yelmo_HALFAR.nml
+++ b/par-gmd/yelmo_HALFAR.nml
@@ -26,6 +26,7 @@
     phys_const      = "EISMINT"
     experiment      = "EISMINT"         ! "None", "EISMINT", "MISMIP3D", "BUELER"  to apply special boundary conditions   
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"
@@ -98,7 +99,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "zero"            ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     

--- a/par-gmd/yelmo_MISMIP3D.nml
+++ b/par-gmd/yelmo_MISMIP3D.nml
@@ -19,6 +19,7 @@
     phys_const      = "MISMIP3D"
     experiment      = "MISMIP3D"        ! "None", "EISMINT", "MISMIP3D", "BUELER"  to apply special boundary conditions   
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"
@@ -91,7 +92,8 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = False             ! use level-set method
-    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    dt_lsf              = -1                ! Deprecated (no effect); kept for backwards compatibility
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations (0 = off)
     calv_flt_method     = "kill-pos"        ! "zero", "simple", "flux", "vm-l19", "vm-m16", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12", "vm-m16"
     


### PR DESCRIPTION
## Summary

Two bugs were preventing every \`par-gmd/*.nml\` file from running:

1. **Missing \`nml_ycalv = \"ycalv\"\`** in the \`&yelmo\` block. The calving parameters were promoted to their own \`&ycalv\` group at some point, but the par-gmd files were never updated alongside \`par/\`. \`nml_read\` aborts with \`parameter not found: nml_ycalv\` before any simulation work begins.

2. **Missing \`lsf_redist_n_iter\`** in the \`&ycalv\` block. PR #29 added this required parameter and updated \`par/*.nml\` but missed the \`par-gmd/\` files. Without (1) above the \`&ycalv\` block was never read so this never fired; with (1) added, it's the next thing \`nml_read\` aborts on.

Both fixes match the conventions established in \`par/\` (default 5 redistancing iterations; \`dt_lsf\` marked deprecated).

## Files affected

\`par-gmd/yelmo_Antarctica.nml\`, \`par-gmd/yelmo_EISMINT_expa.nml\`, \`par-gmd/yelmo_EISMINT_expf.nml\`, \`par-gmd/yelmo_EISMINT_moving.nml\`, \`par-gmd/yelmo_HALFAR.nml\`, \`par-gmd/yelmo_MISMIP3D.nml\` — same +3/-1 line edit per file.

## Test plan

- [x] Verified \`make mismip\` runs the MISMIP3D RF rate-factor experiment to completion (12 kyr, no NaN, H_max ~3.5 km, 600 ice cells).
- [ ] Other par-gmd benchmarks not individually tested but use the same fixed pattern.