### PR TITLE
Fix L<->R asymmetry in energy SSA solver lateral BC + add regression test

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -147,6 +147,13 @@ ssa_energy_sym : yelmo-static tests/test_ssa_energy_sym.f90
 		@echo "    test_ssa_energy_sym.x is ready."
 		@echo " "
 
+ssa_energy_lr_sym : yelmo-static tests/test_ssa_energy_lr_sym.f90
+		$(FC) $(DFLAGS) $(FFLAGS) $(INC_FESMUTILS) $(INC_LIS) -o $(bindir)/test_ssa_energy_lr_sym.x tests/test_ssa_energy_lr_sym.f90 \
+			-L${CURDIR}/libyelmo/include -lyelmo $(LFLAGS)
+		@echo " "
+		@echo "    test_ssa_energy_lr_sym.x is ready."
+		@echo " "
+
 mismip1 : yelmo-static
 		$(FC) $(DFLAGS) $(FFLAGS) $(INC_FESMUTILS) $(INC_LIS) -o $(bindir)/yelmo_mismip.x tests/yelmo_mismip_new.f90 \
 			-L${CURDIR}/libyelmo/include -lyelmo $(LFLAGS)

--- a/src/physics/solver_ssa_ac_energy.f90
+++ b/src/physics/solver_ssa_ac_energy.f90
@@ -296,10 +296,19 @@ contains
                 lgs%a_value(k) = -2.0_wp*N_aa(i,j) - N_ab(i,jm1)
                 lgs%a_index(k) = nc
 
-                ! Right-hand side: driving stress + (optional) calving-front boundary work
+                ! Right-hand side: driving stress + (optional) calving-front boundary work.
+                ! Sign of the boundary work follows the outward normal at the front:
+                !   ice on left,  ocean on right  -> n = +x  -> +taul_int*dy
+                !   ocean on left, ice on right   -> n = -x  -> -taul_int*dy
+                ! Without the sign split the same +taul_int*dy is applied at left
+                ! and right fronts, breaking L<->R symmetry of b.
                 lgs%b_value(nr) = -taud_acx(i,j)*dxdy
                 if (ssa_mask_acx(i,j) .eq. 3) then
-                    lgs%b_value(nr) = lgs%b_value(nr) + taul_int_acx(i,j)*dy
+                    if (is_equal(f_ice(i,j),1.0_wp) .and. f_ice(ip1,j) .lt. 1.0_wp) then
+                        lgs%b_value(nr) = lgs%b_value(nr) + taul_int_acx(i,j)*dy
+                    else
+                        lgs%b_value(nr) = lgs%b_value(nr) - taul_int_acx(i,j)*dy
+                    end if
                 end if
                 lgs%x_value(nr) = ux(i,j)
 
@@ -452,7 +461,11 @@ contains
 
                 lgs%b_value(nr) = -taud_acy(i,j)*dxdy
                 if (ssa_mask_acy(i,j) .eq. 3) then
-                    lgs%b_value(nr) = lgs%b_value(nr) + taul_int_acy(i,j)*dx
+                    if (is_equal(f_ice(i,j),1.0_wp) .and. f_ice(i,jp1) .lt. 1.0_wp) then
+                        lgs%b_value(nr) = lgs%b_value(nr) + taul_int_acy(i,j)*dx
+                    else
+                        lgs%b_value(nr) = lgs%b_value(nr) - taul_int_acy(i,j)*dx
+                    end if
                 end if
                 lgs%x_value(nr) = uy(i,j)
 

--- a/tests/README_symcheck.md
+++ b/tests/README_symcheck.md
@@ -1,0 +1,120 @@
+# SSA-energy reflection-symmetry checks
+
+Two layers of testing protect against the L↔R / T↔B asymmetry bug that was
+fixed in `solver_ssa_ac_energy`: a fast unit test on the linear assembler
+itself, and a slower run-based check on the integrated H_ice field of a
+known-symmetric setup (CalvingMIP exp1 on its circular domain).
+
+## What this is checking
+
+The energy SSA assembler builds `K · u = b` over the C-grid. For an input
+configuration that is mirror-symmetric about a vertical (or horizontal) line,
+both `K` and `b` must be equivariant under the C-grid reflection `P`:
+
+```
+ux(i, j) at right face of cell i  ->  ux(nx-i,   j) with sign -1
+uy(i, j) at top face of cell i    ->  uy(nx+1-i, j) with sign +1
+```
+
+If `K` and `b` respect this symmetry, the linear solve produces a
+reflection-symmetric `u`, and any downstream physics (viscosity update,
+mass transport, …) that is itself symmetry-preserving will keep H_ice
+mirror-symmetric.
+
+`test_ssa_energy_sym` (existing) checks `K = Kᵀ`, which CG needs but is
+**not** the same property. `test_ssa_energy_lr_sym` (here) is the missing
+reflection-equivariance check that catches the bug `test_ssa_energy_sym`
+let through.
+
+## Layer 1 — unit test on the assembler
+
+Direct, deterministic, no I/O. Builds three mirror-symmetric ice
+configurations (vertical strip, horizontal strip, square patch), turns on
+`taul_int` at the calving fronts, calls
+`linear_solver_matrix_ssa_ac_csr_2D_energy` once, and walks the assembled
+`K` and `b` for reflection equivariance. Fails fast on regression.
+
+```bash
+# Build and run (from repo root):
+make ssa_energy_lr_sym
+./libyelmo/bin/test_ssa_energy_lr_sym.x
+echo $?
+```
+
+Expected output ends with:
+
+```
+ ALL CASES PASS: K and b are reflection-symmetric
+```
+
+and exit status 0. On regression the program prints the failing rows
+(`b x row=…`, `K x (n,c)=…`) with the offending values, and exits with
+status 1.
+
+## Layer 2 — run-based check on H_ice (CalvingMIP exp1)
+
+The unit test only exercises the assembler. To catch regressions further
+downstream (e.g. a non-equivariant viscosity stencil, an asymmetric LSF
+advection step, a beta-staggering bug at the grounding line), run a short
+CalvingMIP exp1 with both `ssa_solver = "energy"` and `ssa_solver =
+"residual"` and compare H_ice symmetry:
+
+```bash
+# 1. Stage two run dirs differing only in ssa_solver.
+WT=$(pwd)
+for s in energy residual; do
+    mkdir -p tmp/sym/$s/exp1
+    cp par/yelmo_calvingmip.nml tmp/sym/$s/exp1/
+    ln -sf $WT/input    tmp/sym/$s/exp1/input
+    ln -sf $WT/maps     tmp/sym/$s/exp1/maps
+    ln -sf $WT/ice_data tmp/sym/$s/exp1/ice_data
+done
+sed -i'.bak' 's/ssa_solver *= *"energy"/ssa_solver = "residual"/' tmp/sym/residual/exp1/yelmo_calvingmip.nml
+
+# 2. Run both. CalvingMIP exp1 default is 10000 yr; for a quick sanity
+#    check shorten time_end by editing the nml. ~17 min energy, ~10 s
+#    residual on a current Mac.
+make calving
+for s in energy residual; do
+    (cd tmp/sym/$s/exp1 && $WT/libyelmo/bin/yelmo_calving.x yelmo_calvingmip.nml > run.log 2>&1)
+done
+
+# 3. Diff symmetry. The residual baseline reaches machine precision
+#    (~1e-7); the energy solver should match it to within a few percent.
+julia tests/symcheck.jl tmp/sym/energy/exp1/yelmo2D.nc tmp/sym/residual/exp1/yelmo2D.nc
+```
+
+Healthy output (post-fix):
+
+```
+tmp/sym/energy/exp1/yelmo2D.nc
+  shape=(65, 65)  Hmax= 1296.22  …
+  asym L-R   : Linf=4.492e-03  L1=2.553e-04
+  …
+tmp/sym/residual/exp1/yelmo2D.nc
+  shape=(65, 65)  Hmax= 1281.16  …
+  asym L-R   : Linf=2.382e-07  L1=3.154e-08
+  …
+```
+
+Regression output (pre-fix, for reference):
+
+```
+  asym L-R   : Linf=7.189e-01  L1=1.817e-01    # 72% of Hmax
+```
+
+`Hmax` for the energy solver should land within ~1% of the residual baseline
+(~1281 m for the 25 km / 10 kyr exp1 setup); a much larger value indicates
+the front stress is being mis-applied.
+
+### Julia dependencies
+
+`tests/symcheck.jl` needs `NCDatasets` (everything else is stdlib). One-time
+setup in your global Julia env:
+
+```julia
+import Pkg; Pkg.add("NCDatasets")
+```
+
+If you prefer Python, the original `symcheck.py` predecessor lived in
+`tmp/symcheck.py` during development; it does the same thing with `netCDF4`.

--- a/tests/symcheck.jl
+++ b/tests/symcheck.jl
@@ -1,0 +1,73 @@
+#!/usr/bin/env julia
+# Quantify L<->R, T<->B and 180-deg-rotation asymmetry of H_ice (lithk)
+# in one or more yelmo2D.nc outputs.
+#
+# Intended use: cross-check that a symmetric setup (e.g. CalvingMIP exp1 on
+# its circular domain) produces a reflection-symmetric ice thickness field.
+# Sentinel fills (|H| > 9000) are masked as missing; cells where either side
+# of the comparison is missing are excluded from the mean.
+#
+# Usage:
+#   julia --project tests/symcheck.jl path/to/yelmo2D.nc [more.nc ...]
+#
+# Dependencies: NCDatasets, Statistics, Printf (stdlib).
+#   julia> import Pkg; Pkg.add("NCDatasets")
+#
+# Output: per-file shape, Hmax, ice cell count, and Linf/L1 of the
+# asymmetry under each of three reflections, normalised by Hmax.
+
+using NCDatasets, Statistics, Printf
+
+const FILL_THRESHOLD = 9000.0   # |H| above this counts as a sentinel fill
+
+function diag(path::AbstractString; label::AbstractString = path)
+    if !isfile(path)
+        println(@sprintf("%32s: MISSING (%s)", label, path))
+        return
+    end
+    H = NCDataset(path, "r") do nc
+        var = haskey(nc, "lithk") ? "lithk" : "H_ice"
+        Array{Float64}(nc[var][:, :, end])      # last timestep, (xc, yc)
+    end
+    H[abs.(H) .> FILL_THRESHOLD] .= NaN          # treat sentinel fills as missing
+    Hmax = maximum(filter(!isnan, abs.(H)); init = 0.0)
+    if Hmax == 0
+        println(@sprintf("%s: all-zero H_ice", label)); return
+    end
+    nice = count(!isnan, H)
+
+    function stats(d)
+        a = abs.(d) ./ Hmax
+        finite = .!isnan.(a)
+        any(finite) || return (NaN, NaN)
+        (maximum(a[finite]), mean(a[finite]))
+    end
+
+    H_lr  = reverse(H, dims = 1)                 # (xc, yc) so dim 1 is x
+    H_tb  = reverse(H, dims = 2)
+    H_rot = reverse(reverse(H, dims = 1), dims = 2)
+    lr_inf, lr_l1   = stats(H .- H_lr)
+    tb_inf, tb_l1   = stats(H .- H_tb)
+    rot_inf, rot_l1 = stats(H .- H_rot)
+
+    Hmean = mean(filter(!isnan, H))
+    println(label)
+    println(@sprintf("  shape=%s  Hmax=%8.2f  Hmean=%8.2f  ice_cells=%d",
+                     string(size(H)), Hmax, Hmean, nice))
+    println(@sprintf("  asym L-R   : Linf=%.3e  L1=%.3e", lr_inf, lr_l1))
+    println(@sprintf("  asym T-B   : Linf=%.3e  L1=%.3e", tb_inf, tb_l1))
+    println(@sprintf("  asym 180rot: Linf=%.3e  L1=%.3e", rot_inf, rot_l1))
+    println()
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    if isempty(ARGS)
+        println(stderr, "Usage: julia tests/symcheck.jl path/to/yelmo2D.nc [more.nc ...]")
+        exit(2)
+    end
+    for arg in ARGS
+        # Match the Python script's "..../tmp/<...>" label trimming when present.
+        label = occursin("/tmp/", arg) ? split(arg, "/tmp/")[end] : arg
+        diag(arg; label = label)
+    end
+end

--- a/tests/test_ssa_energy_lr_sym.f90
+++ b/tests/test_ssa_energy_lr_sym.f90
@@ -1,0 +1,371 @@
+program test_ssa_energy_lr_sym
+    ! Verify the energy SSA assembler is equivariant under L<->R (and T<->B)
+    ! reflection of the C-grid. This complements test_ssa_energy_sym which
+    ! checks K = K^T algebraically; here we check that K and b respect the
+    ! reflection symmetry of a mirror-symmetric calving-front configuration.
+    !
+    ! Background: the bug fixed in commit "solver_ssa_ac_energy: flip
+    ! taul_int sign at left fronts" added the boundary-work term taul_int*dy
+    ! to b with a fixed +sign at every ssa_mask=3 cell. Physically the
+    ! contribution is (sigma . n) . u dl and the outward normal n flips
+    ! between left and right fronts, so the sign must flip too. The
+    ! pre-fix assembler hands the same +taul_int*dy to both sides, breaking
+    ! reflection equivariance of b. K stays mirror-symmetric on the first
+    ! Picard iter but drifts as asymmetric u feeds back through visc_eff.
+    !
+    ! The test is direct: build a strip of ice through the middle of the
+    ! grid (vertical strip for L<->R, horizontal for T<->B), turn on
+    ! taul_int at the two fronts, call the assembler once, then walk every
+    ! row n and check K(n, c) == sign_n * sign_c * K(n_mirror, c_mirror)
+    ! and b(n) == sign_n * b(n_mirror) for every (n, c).
+    !
+    ! C-grid reflection P (about the vertical center line):
+    !   ux(i, j) at right face of cell i  ->  ux(nx-i,   j) with sign -1
+    !   uy(i, j) at top face of cell i    ->  uy(nx+1-i, j) with sign +1
+    ! Mirrors for T<->B follow by exchanging i<->j and ux<->uy.
+
+    use yelmo_defs, only : wp
+    use solver_linear, only : linear_solver_class
+    use solver_ssa_ac_energy, only : linear_solver_matrix_ssa_ac_csr_2D_energy
+
+    implicit none
+
+    integer, parameter :: nx = 11, ny = 11
+    real(wp), parameter :: dx = 5000.0_wp, dy = 5000.0_wp
+    real(wp), parameter :: beta_min = 0.0_wp
+    real(wp), parameter :: tol_K = 1.0e-3_wp     ! abs tol on |K(n,c) - mirror|
+    real(wp), parameter :: tol_b = 1.0e-3_wp     ! abs tol on |b(n) - mirror|
+
+    real(wp) :: ux(nx,ny), uy(nx,ny)
+    real(wp) :: beta_acx(nx,ny), beta_acy(nx,ny)
+    real(wp) :: N_aa(nx,ny)
+    integer  :: ssa_mask_acx(nx,ny), ssa_mask_acy(nx,ny)
+    integer  :: mask_frnt(nx,ny)
+    real(wp) :: H_ice(nx,ny), f_ice(nx,ny)
+    real(wp) :: taud_acx(nx,ny), taud_acy(nx,ny)
+    real(wp) :: taul_int_acx(nx,ny), taul_int_acy(nx,ny)
+
+    type(linear_solver_class) :: lgs
+
+    integer :: total_fail
+    integer :: i, j
+
+    ! ---- Uniform symmetric base inputs ----
+    H_ice         = 1000.0_wp
+    f_ice         = 0.0_wp                  ! Ice-free by default; cases below carve out an ice patch
+    N_aa          = 1.0e10_wp
+    beta_acx      = 0.0_wp                  ! Floating shelf — no basal drag
+    beta_acy      = 0.0_wp
+    taud_acx      = 0.0_wp                  ! Body force off so b at mask=3 isolates taul_int
+    taud_acy      = 0.0_wp
+    ux            = 0.0_wp
+    uy            = 0.0_wp
+    taul_int_acx  = 0.0_wp
+    taul_int_acy  = 0.0_wp
+    mask_frnt     = 0
+    ssa_mask_acx  = 0
+    ssa_mask_acy  = 0
+
+    total_fail = 0
+
+    ! ---------- Case A: vertical ice strip, L<->R reflection ----------
+    ! Ice in cells i = 4..8 (mirror-symmetric about i = (nx+1)/2 = 6).
+    ! LEFT front at ac-edge ux(3, j); RIGHT front at ac-edge ux(8, j).
+    write(*,*)
+    write(*,*) "============================================================"
+    write(*,*) "Case A: vertical ice strip, check L<->R reflection of K, b"
+    write(*,*) "============================================================"
+    call reset_state()
+    do j = 1, ny
+        do i = 4, 8
+            f_ice(i, j) = 1.0_wp                ! Ice cells
+        end do
+        ! ssa_mask_acx semantics:
+        !   0 = no SSA, u=0 ;  1 = interior shelfy-stream ;  3 = lateral BC.
+        ! Interior of strip: i = 4..7 are ac-edges fully inside ice.
+        do i = 4, 7
+            ssa_mask_acx(i, j) = 1
+        end do
+        ! Two fronts:
+        ssa_mask_acx(3, j) = 3                  ! ice-free LEFT, ice RIGHT
+        ssa_mask_acx(8, j) = 3                  ! ice LEFT, ice-free RIGHT
+        ! Activate uy in the interior of the strip too so the cross-coupling
+        ! between ux and uy rows is exercised. Strip spans j = 1..ny so
+        ! every uy ac-node within i = 4..8 is interior.
+        do i = 4, 8
+            ssa_mask_acy(i, j) = 1
+        end do
+        ! Lateral stress: identical magnitude on both fronts. The bug shows
+        ! up as b(left) == +taul ; b(right) == +taul instead of opposite.
+        taul_int_acx(3, j) = 1.0e6_wp
+        taul_int_acx(8, j) = 1.0e6_wp
+    end do
+
+    ! "periodic" = all four sides periodic. boundary_code only knows
+    ! "periodic" and "periodic-x"; the assembler also accepts "periodic-y"
+    ! and "infinite" but stagger_visc_aa_ab via boundary_code does not.
+    ! Case A only needs y to be periodic (so the strip wraps top<->bottom);
+    ! using fully-periodic is fine and keeps the boundary handling out of
+    ! the symmetry check.
+    call linear_solver_matrix_ssa_ac_csr_2D_energy(lgs, ux, uy, beta_acx, beta_acy, N_aa, &
+                ssa_mask_acx, ssa_mask_acy, mask_frnt, H_ice, f_ice, taud_acx, taud_acy, &
+                taul_int_acx, taul_int_acy, dx, dy, beta_min, "periodic", "none")
+    call check_lr_reflection(lgs, total_fail)
+
+    ! ---------- Case B: horizontal ice strip, T<->B reflection ----------
+    ! Symmetric to Case A with i and j roles swapped; tests the uy mask=3 branch.
+    write(*,*)
+    write(*,*) "============================================================"
+    write(*,*) "Case B: horizontal ice strip, check T<->B reflection of K, b"
+    write(*,*) "============================================================"
+    call reset_state()
+    do i = 1, nx
+        do j = 4, 8
+            f_ice(i, j) = 1.0_wp
+        end do
+        do j = 4, 7
+            ssa_mask_acy(i, j) = 1
+        end do
+        ssa_mask_acy(i, 3) = 3                  ! ice-free BELOW, ice ABOVE
+        ssa_mask_acy(i, 8) = 3                  ! ice BELOW, ice-free ABOVE
+        do j = 4, 8
+            ssa_mask_acx(i, j) = 1
+        end do
+        taul_int_acy(i, 3) = 1.0e6_wp
+        taul_int_acy(i, 8) = 1.0e6_wp
+    end do
+
+    call linear_solver_matrix_ssa_ac_csr_2D_energy(lgs, ux, uy, beta_acx, beta_acy, N_aa, &
+                ssa_mask_acx, ssa_mask_acy, mask_frnt, H_ice, f_ice, taud_acx, taud_acy, &
+                taul_int_acx, taul_int_acy, dx, dy, beta_min, "periodic", "none")
+    call check_tb_reflection(lgs, total_fail)
+
+    ! ---------- Case C: square ice patch, both reflections at once ----------
+    ! Ice in cells (i, j) with i in [4,8] AND j in [4,8]. All four fronts
+    ! (left/right/top/bottom) carry taul_int. Both reflections must hold.
+    write(*,*)
+    write(*,*) "============================================================"
+    write(*,*) "Case C: square ice patch, both L<->R and T<->B"
+    write(*,*) "============================================================"
+    call reset_state()
+    do j = 4, 8
+        do i = 4, 8
+            f_ice(i, j) = 1.0_wp
+        end do
+    end do
+    do j = 4, 8
+        ! ux fronts at i = 3 and i = 8, ux interior at i = 4..7
+        ssa_mask_acx(3, j) = 3
+        ssa_mask_acx(8, j) = 3
+        do i = 4, 7
+            ssa_mask_acx(i, j) = 1
+        end do
+        taul_int_acx(3, j) = 1.0e6_wp
+        taul_int_acx(8, j) = 1.0e6_wp
+    end do
+    do i = 4, 8
+        ssa_mask_acy(i, 3) = 3
+        ssa_mask_acy(i, 8) = 3
+        do j = 4, 7
+            ssa_mask_acy(i, j) = 1
+        end do
+        taul_int_acy(i, 3) = 1.0e6_wp
+        taul_int_acy(i, 8) = 1.0e6_wp
+    end do
+
+    call linear_solver_matrix_ssa_ac_csr_2D_energy(lgs, ux, uy, beta_acx, beta_acy, N_aa, &
+                ssa_mask_acx, ssa_mask_acy, mask_frnt, H_ice, f_ice, taud_acx, taud_acy, &
+                taul_int_acx, taul_int_acy, dx, dy, beta_min, "infinite", "none")
+    call check_lr_reflection(lgs, total_fail)
+    call check_tb_reflection(lgs, total_fail)
+
+    write(*,*)
+    write(*,*) "============================================================"
+    if (total_fail == 0) then
+        write(*,*) " ALL CASES PASS: K and b are reflection-symmetric"
+    else
+        write(*,'(a,i0,a)') "  FAIL across ", total_fail, " case(s)"
+        stop 1
+    end if
+
+contains
+
+    subroutine reset_state()
+        ! Re-initialise the per-case scratch arrays so cases don't bleed into each other.
+        f_ice         = 0.0_wp
+        ssa_mask_acx  = 0
+        ssa_mask_acy  = 0
+        taul_int_acx  = 0.0_wp
+        taul_int_acy  = 0.0_wp
+    end subroutine reset_state
+
+    subroutine check_lr_reflection(lgs, total_fail)
+        ! For every row n (== ux at (i,j) when n odd, uy at (i,j) when n even),
+        ! find its L<->R mirror row n_m and verify K and b are reflection-equivariant.
+        type(linear_solver_class), intent(in) :: lgs
+        integer, intent(inout) :: total_fail
+        integer :: sign_lookup_var(2)            ! sign under L<->R for var=1 (ux), var=2 (uy)
+
+        sign_lookup_var(1) = -1                  ! ux flips sign under x-reflection
+        sign_lookup_var(2) = +1                  ! uy unchanged
+        call check_reflection_generic(lgs, total_fail, axis="x", sign_var=sign_lookup_var)
+    end subroutine check_lr_reflection
+
+    subroutine check_tb_reflection(lgs, total_fail)
+        type(linear_solver_class), intent(in) :: lgs
+        integer, intent(inout) :: total_fail
+        integer :: sign_lookup_var(2)
+
+        sign_lookup_var(1) = +1                  ! ux unchanged under y-reflection
+        sign_lookup_var(2) = -1                  ! uy flips sign
+        call check_reflection_generic(lgs, total_fail, axis="y", sign_var=sign_lookup_var)
+    end subroutine check_tb_reflection
+
+    subroutine check_reflection_generic(lgs, total_fail, axis, sign_var)
+        ! Walk every row, compute its mirror under reflection about the given axis,
+        ! then compare K(n, c) <-> sign_n*sign_c*K(n_m, c_m) for every entry and
+        ! b(n) <-> sign_n*b(n_m). Reports worst violations and counts failures.
+        type(linear_solver_class), intent(in) :: lgs
+        integer, intent(inout) :: total_fail
+        character(len=*), intent(in) :: axis     ! "x" for L<->R, "y" for T<->B
+        integer, intent(in) :: sign_var(2)
+
+        integer  :: n, n_m, c, c_m, idx, idx_m
+        integer  :: i_n, j_n, i_m, j_m, i_c, j_c, i_cm, j_cm
+        integer  :: var_n, var_c, sign_n, sign_c
+        real(wp) :: bmax, kmax
+        real(wp) :: db, dK
+        real(wp) :: worst_b, worst_K
+        integer  :: worst_b_n, worst_K_n
+        integer  :: n_b_fail, n_K_fail
+        real(wp) :: val_m, val_n
+        logical  :: found
+
+        bmax = max(maxval(abs(real(lgs%b_value, wp))), 1.0_wp)
+        kmax = max(maxval(abs(real(lgs%a_value, wp))), 1.0_wp)
+
+        worst_b = 0.0_wp;  worst_b_n = 0
+        worst_K = 0.0_wp;  worst_K_n = 0
+        n_b_fail = 0
+        n_K_fail = 0
+
+        do n = 1, lgs%nmax
+            call decode_row(lgs, n, i_n, j_n, var_n)
+            call mirror_index(i_n, j_n, var_n, axis, i_m, j_m)
+            if (i_m < 1 .or. i_m > nx .or. j_m < 1 .or. j_m > ny) cycle
+            if (var_n == 1) then
+                n_m = 2*lgs%ij2n(i_m, j_m) - 1
+            else
+                n_m = 2*lgs%ij2n(i_m, j_m)
+            end if
+            if (n_m == n) cycle                  ! self-mirror row, nothing to check
+            sign_n = sign_var(var_n)
+
+            ! --- b: b(n) = sign_n * b(n_m) ---
+            db = abs(real(lgs%b_value(n), wp) - real(sign_n, wp)*real(lgs%b_value(n_m), wp)) / bmax
+            if (db > tol_b) then
+                n_b_fail = n_b_fail + 1
+                if (n_b_fail <= 5) then
+                    write(*,'(a,a1,a,i0,a,2es14.6,a,es14.6)') "  b ", axis, &
+                        " row=", n, " (n, n_m): ", real(lgs%b_value(n), wp), real(lgs%b_value(n_m), wp), &
+                        "  rel-err=", db
+                end if
+            end if
+            if (db > worst_b) then
+                worst_b = db
+                worst_b_n = n
+            end if
+
+            ! --- K: K(n, c) = sign_n * sign_c * K(n_m, c_m) ---
+            do idx = lgs%a_ptr(n), lgs%a_ptr(n+1)-1
+                c = lgs%a_index(idx)
+                call decode_row(lgs, c, i_c, j_c, var_c)
+                call mirror_index(i_c, j_c, var_c, axis, i_cm, j_cm)
+                if (i_cm < 1 .or. i_cm > nx .or. j_cm < 1 .or. j_cm > ny) cycle
+                if (var_c == 1) then
+                    c_m = 2*lgs%ij2n(i_cm, j_cm) - 1
+                else
+                    c_m = 2*lgs%ij2n(i_cm, j_cm)
+                end if
+                sign_c = sign_var(var_c)
+
+                val_n = real(lgs%a_value(idx), wp)
+                val_m = 0.0_wp
+                found = .FALSE.
+                do idx_m = lgs%a_ptr(n_m), lgs%a_ptr(n_m+1)-1
+                    if (lgs%a_index(idx_m) == c_m) then
+                        val_m = real(lgs%a_value(idx_m), wp)
+                        found = .TRUE.
+                        exit
+                    end if
+                end do
+                ! Missing slot is treated as 0 — what matters is the value.
+                dK = abs(val_n - real(sign_n*sign_c, wp)*val_m) / kmax
+                if (dK > tol_K) then
+                    n_K_fail = n_K_fail + 1
+                    if (n_K_fail <= 5) then
+                        write(*,'(a,a1,a,i0,a,i0,a,2es14.6,a,es14.6)') "  K ", axis, &
+                            " (n,c)=(", n, ",", c, ") (val, mirror): ", val_n, val_m, &
+                            "  rel-err=", dK
+                    end if
+                end if
+                if (dK > worst_K) then
+                    worst_K = dK
+                    worst_K_n = n
+                end if
+            end do
+        end do
+
+        write(*,'(a,a1)')      "  reflection axis      : ", axis
+        write(*,'(a,1x,i0)')   "  b violations         :", n_b_fail
+        write(*,'(a,1x,i0)')   "  K violations         :", n_K_fail
+        write(*,'(a,es12.4,a,i0)') "  max b rel-err        :", worst_b, "   @row=", worst_b_n
+        write(*,'(a,es12.4,a,i0)') "  max K rel-err        :", worst_K, "   @row=", worst_K_n
+        if (n_b_fail /= 0 .or. n_K_fail /= 0) then
+            write(*,*) "  -> FAIL"
+            total_fail = total_fail + 1
+        else
+            write(*,*) "  -> pass"
+        end if
+    end subroutine check_reflection_generic
+
+    subroutine decode_row(lgs, n, i, j, var)
+        ! n -> (i, j, var) where var=1 means ux (n odd), var=2 means uy (n even).
+        type(linear_solver_class), intent(in) :: lgs
+        integer, intent(in)  :: n
+        integer, intent(out) :: i, j, var
+        i   = lgs%n2i((n+1)/2)
+        j   = lgs%n2j((n+1)/2)
+        var = 2 - mod(n, 2)
+    end subroutine decode_row
+
+    subroutine mirror_index(i, j, var, axis, i_m, j_m)
+        ! C-grid reflection. ux lives at the right face of cell i, uy at top face of cell j.
+        ! See header comment for the index map.
+        integer, intent(in)  :: i, j, var
+        character(len=*), intent(in) :: axis
+        integer, intent(out) :: i_m, j_m
+
+        select case (trim(axis))
+            case ("x")
+                if (var == 1) then
+                    i_m = nx - i               ! ux right-face mirror
+                else
+                    i_m = nx + 1 - i           ! uy aa-column mirror
+                end if
+                j_m = j
+            case ("y")
+                if (var == 2) then
+                    j_m = ny - j               ! uy top-face mirror
+                else
+                    j_m = ny + 1 - j           ! ux aa-row mirror
+                end if
+                i_m = i
+            case default
+                ! Unknown axis: return invalid index so caller's bounds check trips.
+                i_m = -1
+                j_m = -1
+        end select
+    end subroutine mirror_index
+
+end program test_ssa_energy_lr_sym


### PR DESCRIPTION
## Summary

- **Physics fix** (`solver_ssa_ac_energy`): the lateral-stress boundary-work term added to `b` at `ssa_mask=3` cells used a fixed `+sign`, but the contribution `(σ·n)·u dl` requires the sign to follow the outward normal, which flips between left and right fronts. Added the missing case-split mirroring the residual assembler's existing logic.
- **Regression test** (`tests/test_ssa_energy_lr_sym.f90`): direct check that `K` and `b` are equivariant under the C-grid L↔R / T↔B reflection on three mirror-symmetric configurations (vertical strip, horizontal strip, square patch). `test_ssa_energy_sym` only checks `K = Kᵀ` (which CG needs but is **not** the same property) and let this bug through.
- **Run-based diagnostic** (`tests/symcheck.jl` + `tests/README_symcheck.md`): Julia + NetCDF helper + how-to for cross-checking H_ice symmetry between `ssa_solver = "energy"` and `ssa_solver = "residual"` on CalvingMIP exp1.

## Impact (CalvingMIP exp1, circular domain, 25 km, 10000 yr)

| | `Hmax` | L–R Linf asym (/Hmax) |
|---|---:|---:|
| pre-fix energy | 1865 m | **0.72** |
| **post-fix energy** | **1296 m** | **4.5e-3** |
| residual baseline | 1281 m | 2.4e-7 |

Pre-fix energy was severely asymmetric and unstable (also crashed mid-run on an earlier revision). Post-fix matches the residual baseline to ~1% on `Hmax` and reduces asymmetry by 2.5 orders of magnitude.

## Test plan

- [x] `make ssa_energy_lr_sym && ./libyelmo/bin/test_ssa_energy_lr_sym.x` → all four checks pass at `max rel-err = 0.000E+00`.
- [x] Same binary built against the pre-fix assembler fails with `b rel-err = 2.0` on every front-row pair (`K rel-err = 0` confirms the bug was b-only).
- [x] `make calving` then full 10000 yr CalvingMIP exp1 with both solvers; `julia tests/symcheck.jl` reports the numbers in the table above.
- [x] Existing `make ssa_energy_sym` still passes on the fix.