### PR TITLE
calvingmip: unfreeze the LSF front and fix exp1 2D-writer outputs (#34)

### DIFF
--- a/par/yelmo_calvingmip.nml
+++ b/par/yelmo_calvingmip.nml
@@ -164,7 +164,7 @@
     z0              = -300.0            ! [m] Bedrock rel. to sea level, lower limit
     z1              =  200.0            ! [m] Bedrock rel. to sea level, upper limit
     cf_min          =  1e4              ! [-- or deg] Minimum value of cf
-    cf_ref          =  1e4              ! [-- or deg] Reference/const/max value of cf
+    cf_ref          =  3.165176e4       ! [-- or deg] Reference/const/max value of cf (Yelmo.jl calvingmip value)
 /
 
 &yneff 

--- a/src/physics/solver_advection.f90
+++ b/src/physics/solver_advection.f90
@@ -202,15 +202,8 @@ contains
                 bcs(1:4) = "infinite"
 
             case("zeros")
-                ! Treat "zeros" as zero-gradient (Neumann) at the
-                ! domain edge, consistent with the BND_ZEROS branch
-                ! in `get_neighbor_indices_bc_codes`. The original
-                ! Dirichlet-zero handling forced the edge cell value
-                ! to 0 every step, which created a spurious LSF=0
-                ! contour at the domain boundary — visible right
-                ! next to the real ice front at the calving radius
-                ! and damping the front cycle in CalvingMIP exp2.
-                bcs(1:4) = "infinite"
+
+                bcs(1:4) = "zero"
 
             case("periodic","periodic-xy")
 

--- a/src/physics/solver_advection.f90
+++ b/src/physics/solver_advection.f90
@@ -202,8 +202,15 @@ contains
                 bcs(1:4) = "infinite"
 
             case("zeros")
-
-                bcs(1:4) = "zero" 
+                ! Treat "zeros" as zero-gradient (Neumann) at the
+                ! domain edge, consistent with the BND_ZEROS branch
+                ! in `get_neighbor_indices_bc_codes`. The original
+                ! Dirichlet-zero handling forced the edge cell value
+                ! to 0 every step, which created a spurious LSF=0
+                ! contour at the domain boundary — visible right
+                ! next to the real ice front at the calving radius
+                ! and damping the front cycle in CalvingMIP exp2.
+                bcs(1:4) = "infinite"
 
             case("periodic","periodic-xy")
 

--- a/src/yelmo_ice.f90
+++ b/src/yelmo_ice.f90
@@ -1233,8 +1233,15 @@ contains
         !call yelmo_restart_write(dom,"./yelmo_check_z_bed.nc",time=0.0_wp,init=.TRUE.)
         !stop 
 
-        ! Finally lets initialize the LSF mask
-        call LSFinit(dom%tpo%now%lsf,dom%tpo%now%H_ice,dom%bnd%z_bed,dom%bnd%z_sl,dom%tpo%par%dx)
+        ! Finally lets initialize the LSF mask -- but only if we are not
+        ! restarting; the restart file already carries a distance field
+        ! built up by the Sussman/Osher redistancing, and overwriting it
+        ! with a saturated ±1 step here would force the LSF to "warm up"
+        ! again before sub-grid front motion could resume (see #34
+        ! follow-up: CalvingMIP exp2 re-advance was broken by this).
+        if (.not. dom%par%use_restart) then
+            call LSFinit(dom%tpo%now%lsf,dom%tpo%now%H_ice,dom%bnd%z_bed,dom%bnd%z_sl,dom%tpo%par%dx)
+        end if
 
         return 
 

--- a/src/yelmo_io.f90
+++ b/src/yelmo_io.f90
@@ -672,7 +672,7 @@ contains
         call nc_read_interp(filename,"cmb_flt",     tpo%now%cmb_flt,    ncid=ncid,start=[1,1,n],count=[nx,ny,1],mps=mps)
         !call nc_read_interp(filename,"cmb_flt_x",   tpo%now%cmb_flt_x,  ncid=ncid,start=[1,1,n],count=[nx,ny,1],mps=mps)
         !call nc_read_interp(filename,"cmb_flt_y",   tpo%now%cmb_flt_y,  ncid=ncid,start=[1,1,n],count=[nx,ny,1],mps=mps)
-        !call nc_read_interp(filename,"lsf",         tpo%now%lsf,ncid=ncid,start=[1,1,n],count=[nx,ny,1],mps=mps)
+        call nc_read_interp(filename,"lsf",         tpo%now%lsf,ncid=ncid,start=[1,1,n],count=[nx,ny,1],mps=mps)
         !call nc_read_interp(filename,"dlsf",        tpo%now%dlsf,ncid=ncid,start=[1,1,n],count=[nx,ny,1],mps=mps)
         call nc_read_interp(filename,"cmb_grnd",    tpo%now%cmb_grnd,   ncid=ncid,start=[1,1,n],count=[nx,ny,1],mps=mps)
         call nc_read_interp(filename,"eps_eff",     tpo%now%eps_eff,    ncid=ncid,start=[1,1,n],count=[nx,ny,1],mps=mps)

--- a/src/yelmo_tools.f90
+++ b/src/yelmo_tools.f90
@@ -175,34 +175,39 @@ contains
 
         select case(BC)
 
-            case(BND_INFINITE)
+            case(BND_ZEROS,BND_INFINITE)
+                ! Clamp neighbour indices to the domain edge so that ghost
+                ! reads return the edge value (Neumann-zero / zero-gradient
+                ! extension). Previously BND_ZEROS fell into the periodic
+                ! DEFAULT branch, silently wrapping the field around the
+                ! domain — see issue #34 follow-up.
                 im1 = max(i-1,1)
-                ip1 = min(i+1,nx) 
+                ip1 = min(i+1,nx)
                 jm1 = max(j-1,1)
-                jp1 = min(j+1,ny) 
+                jp1 = min(j+1,ny)
 
             case(BND_MISMIP3D,BND_TROUGH)
                 im1 = max(i-1,1)
-                ip1 = min(i+1,nx) 
+                ip1 = min(i+1,nx)
                 jm1 = j-1
                 if (jm1 .eq. 0)    jm1 = ny
                 jp1 = j+1
-                if (jp1 .eq. ny+1) jp1 = 1 
-                
-            case DEFAULT 
+                if (jp1 .eq. ny+1) jp1 = 1
+
+            case DEFAULT
                 ! Periodic, periodic-x (for now treat the same way)
 
                 im1 = i-1
-                if (im1 .eq. 0)    im1 = nx 
+                if (im1 .eq. 0)    im1 = nx
                 ip1 = i+1
-                if (ip1 .eq. nx+1) ip1 = 1 
+                if (ip1 .eq. nx+1) ip1 = 1
 
                 jm1 = j-1
                 if (jm1 .eq. 0)    jm1 = ny
                 jp1 = j+1
-                if (jp1 .eq. ny+1) jp1 = 1 
+                if (jp1 .eq. ny+1) jp1 = 1
 
-        end select 
+        end select
 
         return
 

--- a/src/yelmo_topography.f90
+++ b/src/yelmo_topography.f90
@@ -791,10 +791,17 @@ end if
                        tpo%now%mask_adv,tpo%par%dx,tpo%par%dy,dt,tpo%par%solver,tpo%par%boundaries)
 
         ! Restore |grad lsf| ~= 1 near the front via Sussman/Osher
-        ! Hamilton-Jacobi redistancing. Replaces the old ad-hoc
-        ! neighbour-snap and periodic ±1 re-flag.
+        ! Hamilton-Jacobi redistancing.
+        !
+        ! lsf is in normalized ±1 units (LSFupdate saturates it to that
+        ! range), so we redistance in grid-cell units (dx=dy=1) so that
+        ! the PDE drives |grad lsf| -> 1 per cell near the zero level
+        ! set, producing lsf ≈ ±1 at adjacent cells. Passing physical
+        ! dx (e.g. 25000 m) would make the smoothed sign function
+        ! ≈ ±lsf/dx ≈ 0 several cells out from the front, freezing
+        ! the front in place (see issue #34). Matches Yelmo.jl.
         if (tpo%par%lsf_redist_n_iter .gt. 0) then
-            call LSFredistance(tpo%now%lsf,tpo%par%dx,tpo%par%dy, &
+            call LSFredistance(tpo%now%lsf,1.0_wp,1.0_wp, &
                                tpo%par%lsf_redist_n_iter,tpo%par%boundaries)
         end if
 

--- a/src/yelmo_topography.f90
+++ b/src/yelmo_topography.f90
@@ -790,6 +790,11 @@ end if
         call LSFupdate(tpo%now%dlsfdt,tpo%now%lsf,tpo%now%cr_acx,tpo%now%cr_acy,dyn%now%ux_bar,dyn%now%uy_bar, &
                        tpo%now%mask_adv,tpo%par%dx,tpo%par%dy,dt,tpo%par%solver,tpo%par%boundaries)
 
+        ! LSF should not affect points above sea level. Pin BEFORE the
+        ! redistance pass so that phi0 carries the right (land = -1) value
+        ! into the Sussman/Osher iteration — Yelmo.jl uses this order.
+        where(bnd%z_bed .gt. bnd%z_sl) tpo%now%lsf = -1.0_wp
+
         ! Restore |grad lsf| ~= 1 near the front via Sussman/Osher
         ! Hamilton-Jacobi redistancing.
         !
@@ -804,9 +809,6 @@ end if
             call LSFredistance(tpo%now%lsf,1.0_wp,1.0_wp, &
                                tpo%par%lsf_redist_n_iter,tpo%par%boundaries)
         end if
-
-        ! LSF should not affect points above sea level
-        where(bnd%z_bed .gt. bnd%z_sl) tpo%now%lsf = -1.0_wp
 
         ! === Calving ===
         ! Apply calving as a melt rate equal to ice thickness where lsf is positive

--- a/src/yelmo_topography.f90
+++ b/src/yelmo_topography.f90
@@ -787,8 +787,17 @@ end if
         ! === LSF advection ===
         ! Store previous lsf mask. Necessary to avoid compute it two times.
         tpo%now%lsf_n = tpo%now%lsf
+        ! Use "infinite" (Neumann-zero) boundaries for the LSF advection
+        ! regardless of the model-wide tpo%par%boundaries: the LSF is a
+        ! signed-distance field that must continue smoothly outside the
+        ! domain. With a Dirichlet-zero boundary (the "zeros" semantic)
+        ! the matrix builder would force lsf=0 at every edge cell, which
+        ! creates a spurious LSF=0 contour one cell from the boundary and
+        ! the Sussman/Osher redistance fights it every step (see issue
+        ! #34 follow-up). Matches Yelmo.jl, whose Oceananigans `:bounded`
+        ! BC zeros only the halo, leaving edge cells free.
         call LSFupdate(tpo%now%dlsfdt,tpo%now%lsf,tpo%now%cr_acx,tpo%now%cr_acy,dyn%now%ux_bar,dyn%now%uy_bar, &
-                       tpo%now%mask_adv,tpo%par%dx,tpo%par%dy,dt,tpo%par%solver,tpo%par%boundaries)
+                       tpo%now%mask_adv,tpo%par%dx,tpo%par%dy,dt,tpo%par%solver,"infinite")
 
         ! LSF should not affect points above sea level. Pin BEFORE the
         ! redistance pass so that phi0 carries the right (land = -1) value
@@ -805,9 +814,12 @@ end if
         ! dx (e.g. 25000 m) would make the smoothed sign function
         ! ≈ ±lsf/dx ≈ 0 several cells out from the front, freezing
         ! the front in place (see issue #34). Matches Yelmo.jl.
+        ! Boundary is "infinite" for the same reason as the LSF advection
+        ! call above: Neumann-zero / zero-gradient extension is the only
+        ! sensible BC for the SO redistance of a signed-distance field.
         if (tpo%par%lsf_redist_n_iter .gt. 0) then
             call LSFredistance(tpo%now%lsf,1.0_wp,1.0_wp, &
-                               tpo%par%lsf_redist_n_iter,tpo%par%boundaries)
+                               tpo%par%lsf_redist_n_iter,"infinite")
         end if
 
         ! === Calving ===

--- a/tests/yelmo_calving.f90
+++ b/tests/yelmo_calving.f90
@@ -519,12 +519,13 @@ contains
         where(ylmo%tpo%now%H_ice .eq. 0.0_wp) mask_clvmip = 3
         where(ylmo%tpo%now%H_ice .gt. 0.0_wp .and. ylmo%tpo%now%f_grnd .eq. 0.0_wp) mask_clvmip = 2
         where(ylmo%tpo%now%H_ice .gt. 0.0_wp .and. ylmo%tpo%now%f_grnd .gt. 0.0_wp) mask_clvmip = 1
-            
-        ! compute subgrid floating margin
-        !call calc_ice_fraction_new(fice_subgrid,ylmo%tpo%now%H_ice,ylmo%bnd%z_bed,ylmo%bnd%z_sl,ylmo%bnd%c%rho_ice, &
-        !    ylmo%bnd%c%rho_sw,ylmo%tpo%par%boundaries,.TRUE.)
 
-        ! convert velocities into aa-nodes    
+        ! Use the model's actual subgrid ice fraction (tpo%now%f_ice) — the
+        ! prior `fice_subgrid` local was allocated but never assigned, so it
+        ! was uninitialised stack noise.
+        fice_subgrid = ylmo%tpo%now%f_ice
+
+        ! convert velocities into aa-nodes
         do i=2, ylmo%grd%nx-1
         do j=2, ylmo%grd%ny-1
             ux_bar_aa(i,j) = 0.5*(ylmo%dyn%now%ux_bar(i,j)+ylmo%dyn%now%ux_bar(i-1,j))
@@ -535,7 +536,6 @@ contains
 
         where(ylmo%tpo%now%H_ice .eq. 0.0_wp) ux_bar_aa = mv
         where(ylmo%tpo%now%H_ice .eq. 0.0_wp) uy_bar_aa = mv
-        where(ylmo%tpo%now%H_ice .eq. 0.0_wp) H_clvmip  = mv
         where(ylmo%tpo%now%H_ice .eq. 0.0_wp) H_frnt    = mv
         where(ylmo%tpo%now%H_ice .eq. 0.0_wp) calverate = mv
 


### PR DESCRIPTION
Closes #34.

## Problem

CalvingMIP exp1 (and downstream exp2/3/4) couldn't reproduce the protocol's behaviour: the LSF zero contour stayed bit-identical to its initial position (r ≈ 445 km) for the entire 10 kyr spin-up. No floating shelf ever formed; exp2 had no front to cycle.

Root cause is a stack of independent bugs along the LSF code path. Each fix is its own commit.

## Fixes (9 commits)

### 1. `yelmo_topography` — redistance LSF in cell units to free the calving front

`LSFredistance` is a non-dimensional Sussman/Osher operator on a non-dim field (lsf saturated to [-1, 1] by `LSFupdate`). Calling it with physical `dx` (e.g. 25 000 m) scales the smoothed sign `sgn(phi0) = phi0/sqrt(phi0² + ε²)` by ≈ `1/dx`, driving it to ~4×10⁻⁵ in a several-cell band around the zero contour. That band can no longer respond to flow-driven drift, so the front freezes — the exact symptom in issue #34. Pass `1.0_wp, 1.0_wp` instead, matching Yelmo.jl's documented calling convention.

### 2. `yelmo_calving` — fix uninitialised `f_ice` and `lithk` fill in the 2D writer

`write_2D_calvingmip` allocated `fice_subgrid(:,:)` and wrote it to the `f_ice` netCDF variable, but the line that computed it was commented out — so the file held stack noise instead of the model's `[0, 1]` subgrid ice fraction. Also drop the `where(H_ice == 0) H_clvmip = mv` so `lithk` over ice-free cells is `0 m` rather than the netCDF missing value (−9999).

### 3. `par/yelmo_calvingmip` — `cf_ref = 3.165176e4` to match Yelmo.jl

Was `1e4`, giving too little basal drag and H_max ~1350 m vs ~2450 m reference. Now within 1%.

### 4. `yelmo_tools` — treat `BND_ZEROS` as clamped neighbours

`get_neighbor_indices_bc_codes` had no case for `BND_ZEROS = 0`, so `"zeros"` boundary fell through `case DEFAULT` and was silently treated as fully periodic. Dirichlet isn't expressible in an index-only API, so clamp to the domain edge (Neumann-zero / zero-gradient) — the only sensible behaviour for the gradient and stencil callers that go through this function.

### 5. `yelmo_io` — read `lsf` from restart file

The `nc_read_interp(... "lsf" ...)` call in `yelmo_restart_read_topo_bnd` was commented out, so restart loading silently dropped the SO distance field built up over spin-up.

### 6. `yelmo_ice` — skip `LSFinit` on restart so the loaded lsf is kept

`yelmo_init_topo` unconditionally called `LSFinit` after the restart block, re-saturating the lsf to ±1 from H_ice/z_bed and throwing away any distance information. Now guarded by `if (.not. dom%par%use_restart)`. Combined with #5, the LSF distance field now survives the restart cycle.

### 7. `yelmo_topography` — pin above-SL lsf before redistance

Match Yelmo.jl's `calving_step!` order: clamp `lsf = −1` over land first, then run the SO redistance, so phi0 carries the right pinned value into the iteration. Functionally a near-no-op for exp1; order-matches Yelmo.jl for cleaner side-by-side debugging.

### 8. `solver_advection` — initial attempt at fixing the impl-lis boundary

(Subsequently revised by commit #9.) Mapped `"zeros"` to `"infinite"` inside the matrix builder so the LSF advection no longer forced `lsf[edge] = 0` every step.

### 9. `calving_lsf` — pass `"infinite"` to LSF advection / redistance explicitly

Commit #8 fixed the symptom but conflated the two BC semantics: any field advected through `impl-lis` with `"zeros"` ignored the Dirichlet intent. Restore the original distinction in the matrix builder (`"zeros"` = Dirichlet zero, `"infinite"` = Neumann zero) and instead hardcode `"infinite"` at the two LSF call sites in `calc_ytopo_calving_lsf`. The LSF is a signed-distance field that must continue smoothly outside the domain regardless of how the rest of the model handles its boundary, so the choice belongs at the call site — not buried inside the solver.

Result: a user who configures `boundaries="zeros"` for an ice setup that actually reaches the domain edge will get the original Dirichlet behaviour for H_ice (ice clamped to 0, mass leaves the domain) while the LSF still uses Neumann. The two boundary-string semantics stay distinct as intended.

## Results

### CalvingMIP exp1 (25 km, 10 kyr spin-up)

| metric            | before | after  | Yelmo.jl ref |
| ----------------- | ------ | ------ | ------------ |
| `r_ice` (km)      | 445    | 750    | 750          |
| `V_total` (kg)    | 4.79e17 | 1.07e18 | 1.07e18      |
| `A_flt` (m²)      | 0      | 7.97e11 | 8.0e11       |
| `H_max` (m)       | 1296   | 2476   | 2450 (+1%)   |
| `f_ice` 2D range  | stack noise | [0, 1] | [0, 1]       |
| `lithk` over ocean | −9999 | 0      | 0            |

### CalvingMIP exp2 (1 kyr from new exp1 restart, `dtt=5` matching Yelmo.jl `DT_OUTER_YR=5`)

Eight-way ray-traced cardinal front radius:

| t (yr) | Fortran (after fix 8 only) | Fortran (after fix 9, current) | Yelmo.jl |
|---|---|---|---|
| 0 | 749.7 | 749.7 | 762.5 |
| 500 (trough) | 655.8 | 655.8 | 575.1 |
| 1000 (recovery) | 737.4 | **737.4** | 749.7 |

Fix 9 is a no-op for behaviour and a cleanup for design — the LSF boundary handling moves from "matrix-builder secret" to "explicit call-site choice". Edge `lsf` saturates at +1.9..+2.8 throughout the cycle (Yelmo.jl behaviour), instead of being clamped to 0.

Quadrant symmetry holds within rounding throughout exp2.

## Known caveats

- exp2 cycle amplitude is ~half of Yelmo.jl's (~94 km cardinal peak-to-trough vs ~187 km). Cycle shape (timing, full re-advance) is now correct. Suspected cause: slightly different exp1 final state (Fortran has ~80 more grounded cells and a thinner floating shelf), not a single fixable bug.
- exp2 full protocol (5 kyr): separate `dt_min`-runaway kill during the second fast-retreat phase. Model state is healthy when killed.
- exp3 (thule geometry) and exp5: not yet validated.

## Test plan

- [x] CalvingMIP exp1: reaches r=750 km, H_max within 1% of Yelmo.jl fixture.
- [x] CalvingMIP exp2 (1 kyr, dtt=5): front cycles with full re-advance to 737/749 km.
- [x] `lithk` and `f_ice` 2D outputs have physically sensible ranges.
- [x] `"zeros"` vs `"infinite"` boundary semantics stay distinct (regression-safe for non-LSF advection).
- [ ] CalvingMIP exp2 cycle amplitude matches Yelmo.jl to within ~10%.
- [ ] CalvingMIP exp3 spin-up completes without front instability.
- [ ] CalvingMIP exp5 likewise.