### PR TITLE
yelmo_calving: drop -9999 fill for ice-free cells in 2D output

### DIFF
--- a/tests/yelmo_calving.f90
+++ b/tests/yelmo_calving.f90
@@ -534,11 +534,6 @@ contains
         end do
         end do
 
-        where(ylmo%tpo%now%H_ice .eq. 0.0_wp) ux_bar_aa = mv
-        where(ylmo%tpo%now%H_ice .eq. 0.0_wp) uy_bar_aa = mv
-        where(ylmo%tpo%now%H_ice .eq. 0.0_wp) H_frnt    = mv
-        where(ylmo%tpo%now%H_ice .eq. 0.0_wp) calverate = mv
-
         ! Write CalvingMIP variables variables
         call nc_write(filename,"xvelmean",ux_bar_aa,start=[1,1,n],units="m a-1",long_name="X velocity", &
                     standard_name="land_ice_vertical_mean_x_velocity", dims=dims,ncid=ncid)


### PR DESCRIPTION
## Summary
- The CalvingMIP 2D writer in `tests/yelmo_calving.f90` was overwriting `xvelmean`, `yvelmean`, `H_frnt`, and `calverate` with `-9999` (MV) wherever `H_ice == 0`, purely for output. Removed those four `where` lines so ice-free cells carry their natural values (velocities ~0, `H_frnt = 0`, `calverate = cmb_flt`).
- `lithk` was never masked and is unchanged. The 1D writer doesn't do this masking either, so no other call sites were affected.

## Test plan
- [x] `make calving` builds clean
- [x] Re-ran exp1, exp2, exp3, exp4 with the patched binary; all four finish with `yelmo_end:: Finished.`
- [x] `ncdump -v {xvelmean,yvelmean,H_frnt,calverate}` shows zero `-9999` occurrences in all four `yelmo2D.nc` files
- [x] `tests/symcheck.jl` numbers are unchanged vs. the prior run (change is output-only, doesn't touch the integration)